### PR TITLE
Add KafkaStream.Store method

### DIFF
--- a/core/Errors/InvalidStateStoreException.cs
+++ b/core/Errors/InvalidStateStoreException.cs
@@ -1,0 +1,45 @@
+﻿using Streamiz.Kafka.Net.Processors;
+using System;
+
+namespace Streamiz.Kafka.Net.Errors
+{
+    /// <summary>
+    /// Indicates that there was a problem when trying to access a  <see cref="IStateStore"/>, i.e, the Store is no longer 
+    /// valid because it is closed or doesn't exist any more due to a rebalance.
+    /// 
+    /// These exceptions may be transient, i.e., during a rebalance it won't be possible to query the stores as they are
+    /// being(re)-initialized. Once the rebalance has completed the stores will be available again. Hence, it is valid
+    /// to backoff and retry when handling this exception.
+    /// 
+    /// </summary>
+    public class InvalidStateStoreException : Exception
+    {
+        /// <summary>
+        /// Constructor with exception message
+        /// </summary>
+        /// <param name="message">Exception message</param>
+        public InvalidStateStoreException(string message) 
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Constructor with inner exception
+        /// </summary>
+        /// <param name="innerException">Inner exception</param>
+        public InvalidStateStoreException(Exception innerException) 
+            : this("", innerException)
+        {
+        }
+
+        /// <summary>
+        /// Constructor with exception message and inner exception
+        /// </summary>
+        /// <param name="message">Exception message</param>
+        /// <param name="innerException">Inner exception</param>
+        public InvalidStateStoreException(string message, Exception innerException) 
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/core/KafkaStream.cs
+++ b/core/KafkaStream.cs
@@ -332,7 +332,7 @@ namespace Streamiz.Kafka.Net
         /// </summary>
         /// <typeparam name="T">return type</typeparam>
         /// <param name="storeName">name of the store to find</param>
-        /// <param name="queryableStoreType">accept only stores that are accepted by <see cref="IQueryableStoreType{T}.Accepts(IStateStore)"</param>
+        /// <param name="queryableStoreType">accept only stores that are accepted by <see cref="IQueryableStoreType{T}.Accepts(IStateStore)"/></param>
         /// <returns>A facade wrapping the local <see cref="IStateStore"/> instances</returns>
         /// <exception cref="InvalidStateStoreException ">if Kafka Streams is (re-)initializing or a store with <code>storeName</code> } and
         /// <code>queryableStoreType</code> doesn't exist </exception>

--- a/core/KafkaStream.cs
+++ b/core/KafkaStream.cs
@@ -256,7 +256,7 @@ namespace Streamiz.Kafka.Net
             this.threads = new IThread[this.configuration.NumStreamThreads];
             var threadState = new Dictionary<long, Processors.ThreadState>();
 
-            List<IStateStoreProvider> stateStoreProviders = new List<IStateStoreProvider>();
+            List<StreamThreadStateStoreProvider> stateStoreProviders = new List<StreamThreadStateStoreProvider>();
             for (int i = 0; i < this.configuration.NumStreamThreads; ++i)
             {
                 var threadId = $"{this.configuration.ApplicationId.ToLower()}-stream-thread-{i}";
@@ -274,7 +274,7 @@ namespace Streamiz.Kafka.Net
 
                 threadState.Add(this.threads[i].Id, this.threads[i].State);
 
-                stateStoreProviders.Add(new StreamThreadStateStoreProvider(this.threads[i]));
+                stateStoreProviders.Add(new StreamThreadStateStoreProvider(this.threads[i], this.topology.Builder));
             }
             
             var manager = new StreamStateManager(this, threadState);
@@ -336,10 +336,10 @@ namespace Streamiz.Kafka.Net
         /// <returns>A facade wrapping the local <see cref="IStateStore"/> instances</returns>
         /// <exception cref="InvalidStateStoreException ">if Kafka Streams is (re-)initializing or a store with <code>storeName</code> } and
         /// <code>queryableStoreType</code> doesn't exist </exception>
-        public T Store<T>(string storeName, IQueryableStoreType<T> queryableStoreType) where T : class//, IStateStore
+        public T Store<T>(string storeName, IQueryableStoreType<T> queryableStoreType) where T : class
         {
             this.ValidateIsRunning();
-            return this.queryableStoreProvider.GetStore(storeName, queryableStoreType);
+            return this.queryableStoreProvider.GetStore(StoreQueryParameters<T>.FromNameAndType(storeName, queryableStoreType));
         }
 
         #region Privates

--- a/core/Processors/IThread.cs
+++ b/core/Processors/IThread.cs
@@ -11,10 +11,9 @@ namespace Streamiz.Kafka.Net.Processors
         bool IsDisposable { get; }
         string Name { get; }
         bool IsRunning { get; }
-        bool IsRunningAndNotRebalancing { get; }
         void Run();
         void Start(CancellationToken token);
-        IEnumerable<ITask> Tasks { get;  }
+        IEnumerable<ITask> ActiveTasks { get;  }
 
         event ThreadStateListener StateChanged;
     }

--- a/core/Processors/IThread.cs
+++ b/core/Processors/IThread.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace Streamiz.Kafka.Net.Processors
@@ -10,8 +11,10 @@ namespace Streamiz.Kafka.Net.Processors
         bool IsDisposable { get; }
         string Name { get; }
         bool IsRunning { get; }
+        bool IsRunningAndNotRebalancing { get; }
         void Run();
         void Start(CancellationToken token);
+        IEnumerable<ITask> Tasks { get;  }
 
         event ThreadStateListener StateChanged;
     }

--- a/core/Processors/ITopicNameExtractor.cs
+++ b/core/Processors/ITopicNameExtractor.cs
@@ -1,5 +1,4 @@
-﻿using Streamiz.Kafka.Net.Processors.Internal;
-using System;
+﻿using System;
 
 namespace Streamiz.Kafka.Net.Processors
 {

--- a/core/Processors/Internal/InternalTopologyBuilder.cs
+++ b/core/Processors/Internal/InternalTopologyBuilder.cs
@@ -246,5 +246,16 @@ namespace Streamiz.Kafka.Net.Processors.Internal
 
 
         #endregion
+
+        #region Describe
+
+        internal ITopologyDescription Describe()
+        {
+            var topologyDes = new TopologyDescription();
+            // TODO : 
+            return topologyDes;
+        }
+
+        #endregion
     }
 }

--- a/core/Processors/StreamTask.cs
+++ b/core/Processors/StreamTask.cs
@@ -40,7 +40,7 @@ namespace Streamiz.Kafka.Net.Processors
                 this.producer = producer;
 
             this.collector = new RecordCollector(logPrefix);
-            collector.Init(ref producer);
+            collector.Init(ref this.producer);
 
             var sourceTimestampExtractor = (processorTopology.GetSourceProcessor(id.Topic) as ISourceProcessor).Extractor;
             Context = new ProcessorContext(configuration, stateMgr).UseRecordCollector(collector);
@@ -69,7 +69,7 @@ namespace Streamiz.Kafka.Net.Processors
             FlushState();
             if (eosEnabled)
             {
-                this.producer.SendOffsetsToTransaction(GetPartitionsWithOffset(), null, configuration.TransactionTimeout);
+                this.producer.SendOffsetsToTransaction(GetPartitionsWithOffset(), this.GroupMetadata, configuration.TransactionTimeout);
                 this.producer.CommitTransaction(configuration.TransactionTimeout);
                 transactionInFlight = false;
                 if (startNewTransaction)

--- a/core/Processors/StreamThread.cs
+++ b/core/Processors/StreamThread.cs
@@ -120,6 +120,8 @@ namespace Streamiz.Kafka.Net.Processors
 
         public bool IsRunning { get; private set; } = false;
 
+        public bool IsRunningAndNotRebalancing => State == ThreadState.RUNNING;
+
         public bool IsDisposable { get; private set; } = false;
 
         public int Id => thread.ManagedThreadId;
@@ -231,6 +233,8 @@ namespace Streamiz.Kafka.Net.Processors
             consumer.Subscribe(builder.GetSourceTopics());
             thread.Start();
         }
+
+        public IEnumerable<ITask> Tasks => this.manager.ActiveTasks;
 
         #endregion
 

--- a/core/Processors/StreamThread.cs
+++ b/core/Processors/StreamThread.cs
@@ -178,7 +178,8 @@ namespace Streamiz.Kafka.Net.Processors
                             }
                         }
 
-                        MaybeCommit();
+                        if (State == ThreadState.RUNNING)
+                            MaybeCommit();
 
                         if (State == ThreadState.PARTITIONS_ASSIGNED)
                         {

--- a/core/Processors/StreamThread.cs
+++ b/core/Processors/StreamThread.cs
@@ -120,8 +120,6 @@ namespace Streamiz.Kafka.Net.Processors
 
         public bool IsRunning { get; private set; } = false;
 
-        public bool IsRunningAndNotRebalancing => State == ThreadState.RUNNING;
-
         public bool IsDisposable { get; private set; } = false;
 
         public int Id => thread.ManagedThreadId;
@@ -234,7 +232,7 @@ namespace Streamiz.Kafka.Net.Processors
             thread.Start();
         }
 
-        public IEnumerable<ITask> Tasks => this.manager.ActiveTasks;
+        public IEnumerable<ITask> ActiveTasks => this.manager.ActiveTasks;
 
         #endregion
 

--- a/core/SerDes/ValueAndTimestampSerDes.cs
+++ b/core/SerDes/ValueAndTimestampSerDes.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Streamiz.Kafka.Net.SerDes
 {
-    public class ValueAndTimestampSerDes<V> : AbstractSerDes<ValueAndTimestamp<V>>
+    internal class ValueAndTimestampSerDes<V> : AbstractSerDes<ValueAndTimestamp<V>>
     {
         public ISerDes<V> InnerSerdes { get; internal set; }
 

--- a/core/SerDes/ValueAndTimestampSerDes.cs
+++ b/core/SerDes/ValueAndTimestampSerDes.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Streamiz.Kafka.Net.SerDes
 {
-    internal class ValueAndTimestampSerDes<V> : AbstractSerDes<ValueAndTimestamp<V>>
+    public class ValueAndTimestampSerDes<V> : AbstractSerDes<ValueAndTimestamp<V>>
     {
         public ISerDes<V> InnerSerdes { get; internal set; }
 

--- a/core/State/InMemory/InMemoryKeyValueStore.cs
+++ b/core/State/InMemory/InMemoryKeyValueStore.cs
@@ -82,6 +82,10 @@ namespace Streamiz.Kafka.Net.State.InMemory
         /// <returns>The value or null if no value is found</returns>
         public byte[] Get(Bytes key) => map.ContainsKey(key) ? map[key] : null;
 
+        /// <summary>
+        /// Return an iterator over all keys in this store. No ordering guarantees are provided.
+        /// </summary>
+        /// <returns>An iterator of all key/value pairs in the store.</returns>
         public IEnumerable<KeyValuePair<Bytes, byte[]>> All() {
             var enumerator = map.GetEnumerator();
             while (enumerator.MoveNext())

--- a/core/State/InMemory/InMemoryKeyValueStore.cs
+++ b/core/State/InMemory/InMemoryKeyValueStore.cs
@@ -73,7 +73,7 @@ namespace Streamiz.Kafka.Net.State.InMemory
         /// <summary>
         /// Flush any cached data. Nothing for moment in <see cref="InMemoryKeyValueStore"/>
         /// </summary>
-        public void Flush(){ /* Nothing => IN MEMORY */ }
+        public void Flush() { /* Nothing => IN MEMORY */ }
 
         /// <summary>
         /// Get the value corresponding to this key.
@@ -81,6 +81,14 @@ namespace Streamiz.Kafka.Net.State.InMemory
         /// <param name="key">The key to fetch</param>
         /// <returns>The value or null if no value is found</returns>
         public byte[] Get(Bytes key) => map.ContainsKey(key) ? map[key] : null;
+
+        public IEnumerable<KeyValuePair<Bytes, byte[]>> All() {
+            var enumerator = map.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                yield return enumerator.Current;
+            }
+        }
 
         /// <summary>
         /// Initialize state store.

--- a/core/State/Internal/CompositeReadOnlyKeyValueStore.cs
+++ b/core/State/Internal/CompositeReadOnlyKeyValueStore.cs
@@ -1,0 +1,75 @@
+﻿using Streamiz.Kafka.Net.Errors;
+using Streamiz.Kafka.Net.Processors;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Streamiz.Kafka.Net.State.Internal
+{
+    internal class CompositeReadOnlyKeyValueStore<K, V> : ReadOnlyKeyValueStore<K, V>
+    {
+        private readonly IStateStoreProvider storeProvider;
+        private readonly IQueryableStoreType<ReadOnlyKeyValueStore<K, V>> storeType;
+        private readonly string storeName;
+
+        public CompositeReadOnlyKeyValueStore(IStateStoreProvider storeProvider, IQueryableStoreType<ReadOnlyKeyValueStore<K, V>> storeType, string storeName)
+        {
+            this.storeProvider = storeProvider;
+            this.storeType = storeType;
+            this.storeName = storeName;
+        }
+
+        public IEnumerable<KeyValuePair<K, V>> All()
+        {
+            // TODO: implement DelegatingPeekingKeyValueIterator
+
+            IEnumerable<ReadOnlyKeyValueStore<K, V>> stores = this.GetAllStores();
+            try
+            {
+                return stores.SelectMany(x => {
+                    return x.All();
+                });
+            }
+            catch (InvalidStateStoreException e)
+            {
+                // TODO is there a point in doing this?
+                throw new InvalidStateStoreException("State store is not available anymore and may have been migrated to another instance; please re-discover its location from the state metadata.", e);
+            }
+        }
+
+        public long ApproximateNumEntries()
+        {
+            IEnumerable<ReadOnlyKeyValueStore<K, V>> stores = this.GetAllStores();
+            long result = 0;
+            foreach (var store in stores)
+            {
+                result += store.ApproximateNumEntries();
+                if (result < 0)
+                {
+                    return long.MaxValue;
+                }
+            }
+            return result;
+        }
+
+        public V Get(K key)
+        {
+            IEnumerable<ReadOnlyKeyValueStore<K, V>> stores = this.GetAllStores();
+            try
+            {
+                return stores.FirstOrDefault(x => x.Get(key) != null).Get(key);
+            }
+            catch(InvalidStateStoreException e)
+            {
+                // TODO is there a point in doing this?
+                throw new InvalidStateStoreException("State store is not available anymore and may have been migrated to another instance; please re-discover its location from the state metadata.", e);
+            }
+        }
+
+        private IEnumerable<ReadOnlyKeyValueStore<K, V>> GetAllStores()
+        {
+            return this.storeProvider.Stores(this.storeName, this.storeType);
+        }
+    }
+}

--- a/core/State/Internal/CompositeReadOnlyKeyValueStore.cs
+++ b/core/State/Internal/CompositeReadOnlyKeyValueStore.cs
@@ -9,11 +9,13 @@ namespace Streamiz.Kafka.Net.State.Internal
 {
     internal class CompositeReadOnlyKeyValueStore<K, V> : ReadOnlyKeyValueStore<K, V>
     {
-        private readonly IStateStoreProvider storeProvider;
+        private readonly IStateStoreProvider<ReadOnlyKeyValueStore<K, V>> storeProvider;
         private readonly IQueryableStoreType<ReadOnlyKeyValueStore<K, V>> storeType;
         private readonly string storeName;
 
-        public CompositeReadOnlyKeyValueStore(IStateStoreProvider storeProvider, IQueryableStoreType<ReadOnlyKeyValueStore<K, V>> storeType, string storeName)
+        public CompositeReadOnlyKeyValueStore(
+            IStateStoreProvider<ReadOnlyKeyValueStore<K, V>> storeProvider,
+            IQueryableStoreType<ReadOnlyKeyValueStore<K, V>> storeType, string storeName)
         {
             this.storeProvider = storeProvider;
             this.storeType = storeType;
@@ -34,7 +36,8 @@ namespace Streamiz.Kafka.Net.State.Internal
             catch (InvalidStateStoreException e)
             {
                 // TODO is there a point in doing this?
-                throw new InvalidStateStoreException("State store is not available anymore and may have been migrated to another instance; please re-discover its location from the state metadata.", e);
+                throw new InvalidStateStoreException("State store is not available anymore and may have " +
+                    "been migrated to another instance; please re-discover its location from the state metadata.", e);
             }
         }
 
@@ -63,7 +66,8 @@ namespace Streamiz.Kafka.Net.State.Internal
             catch(InvalidStateStoreException e)
             {
                 // TODO is there a point in doing this?
-                throw new InvalidStateStoreException("State store is not available anymore and may have been migrated to another instance; please re-discover its location from the state metadata.", e);
+                throw new InvalidStateStoreException("State store is not available anymore and may have " +
+                    "been migrated to another instance; please re-discover its location from the state metadata.", e);
             }
         }
 

--- a/core/State/Internal/IQueryableStoreType.cs
+++ b/core/State/Internal/IQueryableStoreType.cs
@@ -1,0 +1,29 @@
+﻿using Streamiz.Kafka.Net.Processors;
+
+namespace Streamiz.Kafka.Net.State.Internal
+{
+    /// <summary>
+    /// Used to enable querying of custom <see cref="IStateStore"/> types via the <see cref="KafkaStream"/> API.
+    /// </summary>
+    /// <typeparam name="T">The store type</typeparam>
+    // /// <see cref="IQueryableStoreTypes"/>
+    public interface IQueryableStoreType<T>
+    {
+        /// <summary>
+        /// Called when searching for <see cref="IStateStore"/>s to see if they
+        /// match the type expected by implementors of this interface.
+        /// </summary>
+        /// <param name="stateStore">The stateStore</param>
+        /// <returns>true if it is a match</returns>
+        bool Accepts(IStateStore stateStore);
+
+        /// <summary>
+        /// Create an instance of {@code T} (usually a facade) that developers can use
+        /// to query the underlying <see cref="IStateStore"/>s.
+        /// </summary>
+        /// <param name="storeProvider">provides access to all the underlying <see cref="IStateStore"/> instances</param>
+        /// <param name="storeName">The name of the Store</param>
+        /// <returns>a read-only interface over a <see cref="IStateStore"/></returns>
+        T Create(IStateStoreProvider storeProvider, string storeName);
+    }
+}

--- a/core/State/Internal/IQueryableStoreType.cs
+++ b/core/State/Internal/IQueryableStoreType.cs
@@ -6,8 +6,8 @@ namespace Streamiz.Kafka.Net.State.Internal
     /// Used to enable querying of custom <see cref="IStateStore"/> types via the <see cref="KafkaStream"/> API.
     /// </summary>
     /// <typeparam name="T">The store type</typeparam>
-    // /// <see cref="IQueryableStoreTypes"/>
-    public interface IQueryableStoreType<T>
+    /// <seealso cref="QueryableStoreTypes"/>
+    public interface IQueryableStoreType<T> where T : class
     {
         /// <summary>
         /// Called when searching for <see cref="IStateStore"/>s to see if they
@@ -24,6 +24,6 @@ namespace Streamiz.Kafka.Net.State.Internal
         /// <param name="storeProvider">provides access to all the underlying <see cref="IStateStore"/> instances</param>
         /// <param name="storeName">The name of the Store</param>
         /// <returns>a read-only interface over a <see cref="IStateStore"/></returns>
-        T Create(IStateStoreProvider storeProvider, string storeName);
+        T Create(IStateStoreProvider<T> storeProvider, string storeName);
     }
 }

--- a/core/State/Internal/IStateStoreProvider .cs
+++ b/core/State/Internal/IStateStoreProvider .cs
@@ -1,0 +1,24 @@
+﻿using Streamiz.Kafka.Net.Processors;
+using System.Collections.Generic;
+
+namespace Streamiz.Kafka.Net.State.Internal
+{
+    /// <summary>
+    /// Provides access to <see cref="Processors.IStateStore"/>s that have been created
+    /// as part of the <see cref="Stream.Internal.ProcessorTopology"/>.
+    /// To get access to custom stores developers should implement <see cref="IQueryableStoreType{T}"/>.
+    /// </summary>
+    // /// <see cref="IQueryableStoreTypes"/>
+    public interface IStateStoreProvider
+    {
+        /// <summary>
+        /// Find instances of <see cref="Processors.IStateStore"/> that are accepted by <see cref="IQueryableStoreType{T}.Accepts(Processors.IStateStore)"/> and
+        /// have the provided storeName.
+        /// </summary>
+        /// <typeparam name="T">The type of the Store</typeparam>
+        /// <param name="storeName">name of the store</param>
+        /// <param name="queryableStoreType">filter stores based on this queryableStoreType</param>
+        /// <returns>List of the instances of the store in this topology. Empty List if not found</returns>
+        IEnumerable<T> Stores<T>(string storeName, IQueryableStoreType<T> queryableStoreType) where T : class;//, IStateStore;
+    }
+}

--- a/core/State/Internal/IStateStoreProvider .cs
+++ b/core/State/Internal/IStateStoreProvider .cs
@@ -8,17 +8,17 @@ namespace Streamiz.Kafka.Net.State.Internal
     /// as part of the <see cref="Stream.Internal.ProcessorTopology"/>.
     /// To get access to custom stores developers should implement <see cref="IQueryableStoreType{T}"/>.
     /// </summary>
-    // /// <see cref="IQueryableStoreTypes"/>
-    public interface IStateStoreProvider
+    /// <see cref="QueryableStoreTypes"/>
+    /// <typeparam name="T">The type of the store to be provided</typeparam>
+    public interface IStateStoreProvider<T> where T : class
     {
         /// <summary>
         /// Find instances of <see cref="Processors.IStateStore"/> that are accepted by <see cref="IQueryableStoreType{T}.Accepts(Processors.IStateStore)"/> and
         /// have the provided storeName.
         /// </summary>
-        /// <typeparam name="T">The type of the Store</typeparam>
         /// <param name="storeName">name of the store</param>
         /// <param name="queryableStoreType">filter stores based on this queryableStoreType</param>
         /// <returns>List of the instances of the store in this topology. Empty List if not found</returns>
-        IEnumerable<T> Stores<T>(string storeName, IQueryableStoreType<T> queryableStoreType) where T : class;//, IStateStore;
+        IEnumerable<T> Stores(string storeName, IQueryableStoreType<T> queryableStoreType);
     }
 }

--- a/core/State/Internal/QueryableStoreProvider.cs
+++ b/core/State/Internal/QueryableStoreProvider.cs
@@ -6,19 +6,19 @@ using System.Linq;
 namespace Streamiz.Kafka.Net.State.Internal
 {
     /// <summary>
-    /// A wrapper over all of the <see cref="IStateStoreProvider"/>s in a Topology
+    /// A wrapper over all of the <see cref="IStateStoreProvider{T}"/>s in a Topology
     /// </summary>
     internal class QueryableStoreProvider
     {
         // TODO: uncomment GlobalStateStoreProvider code when it is available
 
-        private readonly IEnumerable<IStateStoreProvider> storeProviders;
+        private readonly IEnumerable<StreamThreadStateStoreProvider> storeProviders;
         //private readonly GlobalStateStoreProvider globalStateStoreProvider;
 
-        public QueryableStoreProvider(IEnumerable<IStateStoreProvider> storeProviders
+        public QueryableStoreProvider(IEnumerable<StreamThreadStateStoreProvider> storeProviders
             /*GlobalStateStoreProvider globalStateStoreProvider*/)
         {
-            this.storeProviders = new List<IStateStoreProvider>(storeProviders);
+            this.storeProviders = new List<StreamThreadStateStoreProvider>(storeProviders);
             //this.globalStateStoreProvider = globalStateStoreProvider;
         }
 
@@ -27,10 +27,9 @@ namespace Streamiz.Kafka.Net.State.Internal
         /// storeName and <see cref="IQueryableStoreType{T}"/>
         /// </summary>
         /// <typeparam name="T">The expected type of the returned store</typeparam>
-        /// <param name="storeName">name of the store</param>
-        /// <param name="queryableStoreType">accept stores passing <see cref="IQueryableStoreType{T}.Accepts(Processors.IStateStore)"/></param>
+        /// <param name="storeQueryParameters">parameters to be used when querying for store</param>
         /// <returns>A composite object that wraps the store instances.</returns>
-        public T GetStore<T>(string storeName, IQueryableStoreType<T> queryableStoreType) where T : class//, IStateStore
+        public T GetStore<T>(StoreQueryParameters<T> storeQueryParameters) where T : class
         {
             //IEnumerable<T> globalStore = this.globalStateStoreProvider.stores(storeName, queryableStoreType);
             //if (globalStore.Any())
@@ -39,14 +38,18 @@ namespace Streamiz.Kafka.Net.State.Internal
             //}
 
             IEnumerable<T> allStores = this.storeProviders
-                .SelectMany(store => store.Stores(storeName, queryableStoreType));
+                .SelectMany(store => store.Stores(storeQueryParameters));
 
             if (!allStores.Any())
             {
-                throw new InvalidStateStoreException($"The state store, {storeName}, may have migrated to another instance.");
+                throw new InvalidStateStoreException($"The state store, {storeQueryParameters.StoreName}, may have migrated to another instance.");
             }
 
-            return queryableStoreType.Create(new WrappingStoreProvider(this.storeProviders), storeName);
+            return storeQueryParameters
+                .QueryableStoreType
+                .Create(
+                    new WrappingStoreProvider<T>(this.storeProviders, storeQueryParameters),
+                    storeQueryParameters.StoreName);
         }
     }
 }

--- a/core/State/Internal/QueryableStoreProvider.cs
+++ b/core/State/Internal/QueryableStoreProvider.cs
@@ -1,0 +1,52 @@
+﻿using Streamiz.Kafka.Net.Errors;
+using Streamiz.Kafka.Net.Processors;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Streamiz.Kafka.Net.State.Internal
+{
+    /// <summary>
+    /// A wrapper over all of the <see cref="IStateStoreProvider"/>s in a Topology
+    /// </summary>
+    internal class QueryableStoreProvider
+    {
+        // TODO: uncomment GlobalStateStoreProvider code when it is available
+
+        private readonly IEnumerable<IStateStoreProvider> storeProviders;
+        //private readonly GlobalStateStoreProvider globalStateStoreProvider;
+
+        public QueryableStoreProvider(IEnumerable<IStateStoreProvider> storeProviders
+            /*GlobalStateStoreProvider globalStateStoreProvider*/)
+        {
+            this.storeProviders = new List<IStateStoreProvider>(storeProviders);
+            //this.globalStateStoreProvider = globalStateStoreProvider;
+        }
+
+        /// <summary>
+        /// Get a composite object wrapping the instances of the <see cref="Processors.IStateStore"/> with the provided
+        /// storeName and <see cref="IQueryableStoreType{T}"/>
+        /// </summary>
+        /// <typeparam name="T">The expected type of the returned store</typeparam>
+        /// <param name="storeName">name of the store</param>
+        /// <param name="queryableStoreType">accept stores passing <see cref="IQueryableStoreType{T}.Accepts(Processors.IStateStore)"/></param>
+        /// <returns>A composite object that wraps the store instances.</returns>
+        public T GetStore<T>(string storeName, IQueryableStoreType<T> queryableStoreType) where T : class//, IStateStore
+        {
+            //IEnumerable<T> globalStore = this.globalStateStoreProvider.stores(storeName, queryableStoreType);
+            //if (globalStore.Any())
+            //{
+            //    return queryableStoreType.Create(new WrappingStoreProvider(new[] { this.globalStateStoreProvider })), storeName);
+            //}
+
+            IEnumerable<T> allStores = this.storeProviders
+                .SelectMany(store => store.Stores(storeName, queryableStoreType));
+
+            if (!allStores.Any())
+            {
+                throw new InvalidStateStoreException($"The state store, {storeName}, may have migrated to another instance.");
+            }
+
+            return queryableStoreType.Create(new WrappingStoreProvider(this.storeProviders), storeName);
+        }
+    }
+}

--- a/core/State/Internal/StreamThreadStateStoreProvider.cs
+++ b/core/State/Internal/StreamThreadStateStoreProvider.cs
@@ -1,0 +1,49 @@
+﻿using Streamiz.Kafka.Net.Processors;
+using System.Linq;
+using System.Collections.Generic;
+using Streamiz.Kafka.Net.Errors;
+
+namespace Streamiz.Kafka.Net.State.Internal
+{
+    internal class StreamThreadStateStoreProvider : IStateStoreProvider
+    {
+        private readonly IThread streamThread;
+
+        public StreamThreadStateStoreProvider(IThread streamThread)
+        {
+            this.streamThread = streamThread;
+        }
+
+        public IEnumerable<T> Stores<T>(string storeName, IQueryableStoreType<T> queryableStoreType) where T: class//, IStateStore
+        {
+            if (this.streamThread.State == ThreadState.DEAD)
+            {
+                return Enumerable.Empty<T>();
+            }
+            if (!this.streamThread.IsRunningAndNotRebalancing)
+            {
+                throw new InvalidStateStoreException($"Cannot get state store {storeName} because " +
+                    $"the stream thread is {streamThread.State}, not RUNNING");
+            }
+
+            List<T> stores = new List<T>();
+            foreach (var streamTask in streamThread.Tasks)
+            {
+                IStateStore store = streamTask.GetStore(storeName);
+                if (store != null && queryableStoreType.Accepts(store))
+                {
+                    if (!store.IsOpen)
+                    {
+                        throw new InvalidStateStoreException($"Cannot get state store {storeName} for task {streamTask} because the " +
+                            $"store is not open. The state store may have migrated to another instances.");
+                    }
+
+                    // TODO: handle TimestampedKeyValueStore and TimestampedWindowStore 
+
+                    stores.Add(store as T);
+                }
+            }
+            return stores;
+        }
+    }
+}

--- a/core/State/Internal/StreamThreadStateStoreProvider.cs
+++ b/core/State/Internal/StreamThreadStateStoreProvider.cs
@@ -2,39 +2,44 @@
 using System.Linq;
 using System.Collections.Generic;
 using Streamiz.Kafka.Net.Errors;
+using Streamiz.Kafka.Net.Processors.Internal;
 
 namespace Streamiz.Kafka.Net.State.Internal
 {
-    internal class StreamThreadStateStoreProvider : IStateStoreProvider
+    internal class StreamThreadStateStoreProvider
     {
         private readonly IThread streamThread;
+        private readonly InternalTopologyBuilder internalTopologyBuilder;
 
-        public StreamThreadStateStoreProvider(IThread streamThread)
+        public StreamThreadStateStoreProvider(IThread streamThread, InternalTopologyBuilder internalTopologyBuilder)
         {
             this.streamThread = streamThread;
+            this.internalTopologyBuilder = internalTopologyBuilder;
         }
 
-        public IEnumerable<T> Stores<T>(string storeName, IQueryableStoreType<T> queryableStoreType) where T: class//, IStateStore
+        public IEnumerable<T> Stores<T>(StoreQueryParameters<T> storeQueryParameters) where T: class
         {
+            // TODO: handle 'staleStoresEnabled' and 'partition' when they are added to StoreQueryParameters
+
             if (this.streamThread.State == ThreadState.DEAD)
             {
                 return Enumerable.Empty<T>();
             }
-            if (!this.streamThread.IsRunningAndNotRebalancing)
+            if (!(this.streamThread.State == ThreadState.RUNNING))
             {
-                throw new InvalidStateStoreException($"Cannot get state store {storeName} because " +
+                throw new InvalidStateStoreException($"Cannot get state store {storeQueryParameters.StoreName} because " +
                     $"the stream thread is {streamThread.State}, not RUNNING");
             }
 
             List<T> stores = new List<T>();
-            foreach (var streamTask in streamThread.Tasks)
+            foreach (var streamTask in streamThread.ActiveTasks)
             {
-                IStateStore store = streamTask.GetStore(storeName);
-                if (store != null && queryableStoreType.Accepts(store))
+                IStateStore store = streamTask.GetStore(storeQueryParameters.StoreName);
+                if (store != null && storeQueryParameters.QueryableStoreType.Accepts(store))
                 {
                     if (!store.IsOpen)
                     {
-                        throw new InvalidStateStoreException($"Cannot get state store {storeName} for task {streamTask} because the " +
+                        throw new InvalidStateStoreException($"Cannot get state store {storeQueryParameters.StoreName} for task {streamTask} because the " +
                             $"store is not open. The state store may have migrated to another instances.");
                     }
 

--- a/core/State/Internal/WrappingStoreProvider.cs
+++ b/core/State/Internal/WrappingStoreProvider.cs
@@ -1,0 +1,40 @@
+﻿using Streamiz.Kafka.Net.Errors;
+using Streamiz.Kafka.Net.Processors;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Streamiz.Kafka.Net.State.Internal
+{
+    /// <summary>
+    /// Provides a wrapper over multiple underlying <see cref="IStateStoreProvider"/>s
+    /// </summary>
+    internal class WrappingStoreProvider : IStateStoreProvider
+    {
+        private IEnumerable<IStateStoreProvider> storeProviders;
+
+        public WrappingStoreProvider(IEnumerable<IStateStoreProvider> storeProviders)
+        {
+            this.storeProviders = storeProviders;
+        }
+
+        /// <summary>
+        /// Provides access to <see cref="Processors.IStateStore"/>s accepted by <see cref="IQueryableStoreType{T}.Accepts(Processors.IStateStore)"/>
+        /// </summary>
+        /// <typeparam name="T">The type of the Store</typeparam>
+        /// <param name="storeName">Name of the store</param>
+        /// <param name="type">The <see cref="IQueryableStoreType{T}"/></param>
+        /// <returns>a List of all the stores with the storeName and accepted by<see cref="IQueryableStoreType{T}.Accepts(Processors.IStateStore)"/></returns>
+        public IEnumerable<T> Stores<T>(string storeName, IQueryableStoreType<T> type) where T : class//, IStateStore
+        {
+            var allStores = this.storeProviders
+                .SelectMany(store => store.Stores(storeName, type));
+
+            if (!allStores.Any())
+            {
+                throw new InvalidStateStoreException($"The state store, {storeName}, may have migrated to another instance.");
+            }
+
+            return allStores;
+        }
+    }
+}

--- a/core/State/QueryableStoreTypes.cs
+++ b/core/State/QueryableStoreTypes.cs
@@ -38,7 +38,7 @@ namespace Streamiz.Kafka.Net.State
         {
         }
 
-        public override ReadOnlyKeyValueStore<K, V> Create(IStateStoreProvider storeProvider, string storeName)
+        public override ReadOnlyKeyValueStore<K, V> Create(IStateStoreProvider<ReadOnlyKeyValueStore<K, V>> storeProvider, string storeName)
         {
             return new CompositeReadOnlyKeyValueStore<K, V>(storeProvider, this, storeName);
         }
@@ -50,13 +50,13 @@ namespace Streamiz.Kafka.Net.State
         {
         }
 
-        public override ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>> Create(IStateStoreProvider storeProvider, string storeName)
+        public override ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>> Create(IStateStoreProvider<ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>>> storeProvider, string storeName)
         {
             return new CompositeReadOnlyKeyValueStore<K, ValueAndTimestamp<V>>(storeProvider, this, storeName);
         }
     }
 
-    internal abstract class QueryableStoreTypeMatcher<T> : IQueryableStoreType<T>
+    internal abstract class QueryableStoreTypeMatcher<T> : IQueryableStoreType<T> where T : class
     {
 
         private IEnumerable<Type> matchTo;
@@ -66,7 +66,7 @@ namespace Streamiz.Kafka.Net.State
             this.matchTo = matchTo;
         }
 
-        public abstract T Create(IStateStoreProvider storeProvider, string storeName);
+        public abstract T Create(IStateStoreProvider<T> storeProvider, string storeName);
 
         public bool Accepts(IStateStore stateStore)
         {
@@ -74,5 +74,4 @@ namespace Streamiz.Kafka.Net.State
         }
         
     }
-
 }

--- a/core/State/QueryableStoreTypes.cs
+++ b/core/State/QueryableStoreTypes.cs
@@ -15,6 +15,14 @@ namespace Streamiz.Kafka.Net.State
     public class QueryableStoreTypes
     {
         /// <summary>
+        /// A <see cref="IQueryableStoreType{T}"/> that accepts <see cref="ReadOnlyKeyValueStore{K, V}"/> as T.
+        /// </summary>
+        /// <typeparam name="K">key type of the store</typeparam>
+        /// <typeparam name="V">value type of the store</typeparam>
+        /// <returns><see cref="QueryableStoreTypes.KeyValueStore{K, V}"/></returns>
+        public static IQueryableStoreType<ReadOnlyKeyValueStore<K, V>> KeyValueStore<K, V>() => new KeyValueStoreType<K, V>();
+
+        /// <summary>
         /// A <see cref="IQueryableStoreType{T}"/> that accepts <see cref="ReadOnlyKeyValueStore{K, U}"/> as T where
         /// U is <see cref="ValueAndTimestamp{V}"/>.
         /// </summary>
@@ -22,6 +30,18 @@ namespace Streamiz.Kafka.Net.State
         /// <typeparam name="V">value type of the store</typeparam>
         /// <returns><see cref="QueryableStoreTypes.TimestampedKeyValueStore{K, V}"/></returns>
         public static IQueryableStoreType<ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>>> TimestampedKeyValueStore<K, V>() => new TimestampedKeyValueStoreType<K, V>();
+    }
+
+    internal class KeyValueStoreType<K, V> : QueryableStoreTypeMatcher<ReadOnlyKeyValueStore<K, V>>
+    {
+        public KeyValueStoreType() : base(new[] { typeof(ReadOnlyKeyValueStore<K, V>) })
+        {
+        }
+
+        public override ReadOnlyKeyValueStore<K, V> Create(IStateStoreProvider storeProvider, string storeName)
+        {
+            return new CompositeReadOnlyKeyValueStore<K, V>(storeProvider, this, storeName);
+        }
     }
 
     internal class TimestampedKeyValueStoreType<K, V>: QueryableStoreTypeMatcher<ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>>>

--- a/core/State/QueryableStoreTypes.cs
+++ b/core/State/QueryableStoreTypes.cs
@@ -1,0 +1,48 @@
+﻿using Streamiz.Kafka.Net.Processors;
+using Streamiz.Kafka.Net.State.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Streamiz.Kafka.Net.State
+{
+    public class QueryableStoreTypes
+    {
+        public static IQueryableStoreType<ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>>> TimestampedKeyValueStore<K, V>()
+        {
+            return new TimestampedKeyValueStoreType<K, V>();
+        }
+    }
+
+    internal class TimestampedKeyValueStoreType<K, V>: QueryableStoreTypeMatcher<ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>>>
+    {
+        public TimestampedKeyValueStoreType(): base(new[] { typeof(ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>>), typeof(TimestampedKeyValueStore<K, V>) })
+        {
+        }
+
+        public override ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>> Create(IStateStoreProvider storeProvider, string storeName)
+        {
+            return new CompositeReadOnlyKeyValueStore<K, ValueAndTimestamp<V>>(storeProvider, this, storeName);
+        }
+    }
+
+    internal abstract class QueryableStoreTypeMatcher<T> : IQueryableStoreType<T>
+    {
+
+        private IEnumerable<Type> matchTo;
+
+        public QueryableStoreTypeMatcher(IEnumerable<Type> matchTo)
+        {
+            this.matchTo = matchTo;
+        }
+
+        public abstract T Create(IStateStoreProvider storeProvider, string storeName);
+
+        public bool Accepts(IStateStore stateStore)
+        {
+            return this.matchTo.All(type => type.IsAssignableFrom(stateStore.GetType()));
+        }
+        
+    }
+
+}

--- a/core/State/QueryableStoreTypes.cs
+++ b/core/State/QueryableStoreTypes.cs
@@ -1,17 +1,27 @@
 ﻿using Streamiz.Kafka.Net.Processors;
 using Streamiz.Kafka.Net.State.Internal;
+using Streamiz.Kafka.Net.Stream;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Streamiz.Kafka.Net.State
 {
+    /// <summary>
+    /// Provides access to the <see cref="IQueryableStoreType{T}"/>s provided with <see cref="KafkaStream"/>.
+    /// These can be used with <see cref="KafkaStream.Store{T}(string, IQueryableStoreType{T})"/>
+    /// to access and query the <see cref="IStateStore"/>s that are part of a <see cref="Topology"/>.
+    /// </summary>
     public class QueryableStoreTypes
     {
-        public static IQueryableStoreType<ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>>> TimestampedKeyValueStore<K, V>()
-        {
-            return new TimestampedKeyValueStoreType<K, V>();
-        }
+        /// <summary>
+        /// A <see cref="IQueryableStoreType{T}"/> that accepts <see cref="ReadOnlyKeyValueStore{K, U}"/> as T where
+        /// U is <see cref="ValueAndTimestamp{V}"/>.
+        /// </summary>
+        /// <typeparam name="K">key type of the store</typeparam>
+        /// <typeparam name="V">value type of the store</typeparam>
+        /// <returns><see cref="QueryableStoreTypes.TimestampedKeyValueStore{K, V}"/></returns>
+        public static IQueryableStoreType<ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>>> TimestampedKeyValueStore<K, V>() => new TimestampedKeyValueStoreType<K, V>();
     }
 
     internal class TimestampedKeyValueStoreType<K, V>: QueryableStoreTypeMatcher<ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>>>

--- a/core/State/ReadOnlyKeyValueStore.cs
+++ b/core/State/ReadOnlyKeyValueStore.cs
@@ -1,4 +1,5 @@
-﻿using Streamiz.Kafka.Net.Processors;
+﻿using Streamiz.Kafka.Net.Errors;
+using Streamiz.Kafka.Net.Processors;
 using System.Collections.Generic;
 
 namespace Streamiz.Kafka.Net.State
@@ -14,10 +15,7 @@ namespace Streamiz.Kafka.Net.State
     /// </summary>
     /// <typeparam name="K">the key type</typeparam>
     /// <typeparam name="V">the value type</typeparam>
-
-    // NOTE: in Java implementation ReadOnlyKeyValueStore does not implement ReadOnlyKeyValueStore
-    // I guess it is a mistake. Without this 
-    public interface ReadOnlyKeyValueStore<K, V>//: IStateStore
+    public interface ReadOnlyKeyValueStore<K, V>
     {
         /// <summary>
         /// Get the value corresponding to this key.
@@ -29,6 +27,11 @@ namespace Streamiz.Kafka.Net.State
         // TODO : 
         //KeyValueIterator<K, V> range(K from, K to);
 
+        /// <summary>
+        /// Return an iterator over all keys in this store. No ordering guarantees are provided.
+        /// </summary>
+        /// <returns>An iterator of all key/value pairs in the store.</returns>
+        /// <exception cref="InvalidStateStoreException">if the store is not initialized</exception>
         IEnumerable<KeyValuePair<K, V>> All();
 
         /// <summary>

--- a/core/State/ReadOnlyKeyValueStore.cs
+++ b/core/State/ReadOnlyKeyValueStore.cs
@@ -1,4 +1,7 @@
-﻿namespace Streamiz.Kafka.Net.State
+﻿using Streamiz.Kafka.Net.Processors;
+using System.Collections.Generic;
+
+namespace Streamiz.Kafka.Net.State
 {
     /// <summary>
     /// A key-value store that only supports read operations.
@@ -11,7 +14,10 @@
     /// </summary>
     /// <typeparam name="K">the key type</typeparam>
     /// <typeparam name="V">the value type</typeparam>
-    public interface ReadOnlyKeyValueStore<K, V>
+
+    // NOTE: in Java implementation ReadOnlyKeyValueStore does not implement ReadOnlyKeyValueStore
+    // I guess it is a mistake. Without this 
+    public interface ReadOnlyKeyValueStore<K, V>//: IStateStore
     {
         /// <summary>
         /// Get the value corresponding to this key.
@@ -23,7 +29,7 @@
         // TODO : 
         //KeyValueIterator<K, V> range(K from, K to);
 
-        //KeyValueIterator<K, V> all();
+        IEnumerable<KeyValuePair<K, V>> All();
 
         /// <summary>
         /// Return an approximate count of key-value mappings in this store.

--- a/core/StoreQueryParameters.cs
+++ b/core/StoreQueryParameters.cs
@@ -1,0 +1,57 @@
+﻿using Streamiz.Kafka.Net.State.Internal;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Streamiz.Kafka.Net
+{
+    /// <summary>
+    /// Allows you to pass a variety of parameters when fetching a store for interactive query.
+    /// </summary>
+    /// <typeparam name="T">The type of the Store to be fetched</typeparam>
+    public class StoreQueryParameters<T> where T : class
+    {
+        //public int? Partition { get; private set; }
+
+        //public bool StaleStores { get; private set; }
+
+        /// <summary>
+        /// The name of the state store that should be queried.
+        /// </summary>
+        public string StoreName { get; private set; }
+
+        /// <summary>
+        /// The <see cref="IQueryableStoreType{T}"/> for which key is queried by the user.
+        /// </summary>
+        public IQueryableStoreType<T> QueryableStoreType { get; private set; }
+
+        private StoreQueryParameters(string storeName, IQueryableStoreType<T> queryableStoreType, int? partition, bool staleStores)
+        {
+            StoreName = storeName;
+            QueryableStoreType = queryableStoreType;
+            //Partition = partition;
+            //StaleStores = staleStores;
+        }
+
+        /// <summary>
+        /// Creates <see cref="StoreQueryParameters{T}"/> with specified storeName and queryableStoreType
+        /// </summary>
+        /// <param name="storeName">The name of the state store that should be queried.</param>
+        /// <param name="queryableStoreType">The <see cref="IQueryableStoreType{T}"/> for which key is queried by the user.</param>
+        /// <returns></returns>
+        public static StoreQueryParameters<T> FromNameAndType(string storeName, IQueryableStoreType<T> queryableStoreType)
+        {
+            return new StoreQueryParameters<T>(storeName, queryableStoreType, null, false);
+        }
+
+        //public StoreQueryParameters<T> WithPartition(int partition)
+        //{
+        //    return new StoreQueryParameters<T>(StoreName, QueryableStoreType, partition, StaleStores);
+        //}
+
+        //public StoreQueryParameters<T> EnableStaleStores()
+        //{
+        //    return new StoreQueryParameters<T>(StoreName, QueryableStoreType, Partition, true);
+        //}
+    }
+}

--- a/core/Stream/ITopologyDescription.cs
+++ b/core/Stream/ITopologyDescription.cs
@@ -1,0 +1,41 @@
+﻿using Streamiz.Kafka.Net.Processors;
+using System;
+using System.Collections.Generic;
+
+namespace Streamiz.Kafka.Net.Stream
+{
+    public interface ITopologyDescription
+    {
+        IEnumerable<ISubTopologyDescription> SubTopologies { get; }
+    }
+
+    public interface ISubTopologyDescription
+    {
+        string Id { get; }
+        IEnumerable<INodeDescription> Nodes { get; }
+    }
+
+    public interface INodeDescription
+    {
+        string Name { get; }
+        IEnumerable<INodeDescription> Next { get; }
+        IEnumerable<INodeDescription> Previous { get; }
+    }
+
+    public interface ISourceNodeDescription : INodeDescription
+    {
+        IEnumerable<string> Topics { get; }
+        Type TimestampExtractorType { get; }
+    }
+
+    public interface IProcessorNodeDescription : INodeDescription
+    {
+        IEnumerable<string> Stores { get; }
+    }
+
+    public interface ISinkNodeDescription : INodeDescription
+    {
+        string Topic { get; }
+        Type TopicNameExtractorType { get; }
+    }
+}

--- a/core/Stream/Internal/TopologyDescription.cs
+++ b/core/Stream/Internal/TopologyDescription.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Streamiz.Kafka.Net.Stream.Internal
+{
+    #region TopologyDescription
+
+    internal class TopologyDescription : ITopologyDescription
+    {
+        private readonly IList<ISubTopologyDescription> subtopologies = new List<ISubTopologyDescription>();
+
+        public IEnumerable<ISubTopologyDescription> SubTopologies => subtopologies;
+
+        public TopologyDescription()
+        {
+        }
+
+        public void AddSubtopology(ISubTopologyDescription sub)
+        {
+            if (!SubTopologies.Any(s => s.Id.Equals(sub.Id)))
+                subtopologies.Add(sub);
+        }
+    }
+
+    #endregion
+
+    #region SubTopologyDescription
+
+    internal class SubTopologyDescription : ISubTopologyDescription
+    {
+        public string Id { get; }
+
+        public IEnumerable<INodeDescription> Nodes { get; }
+
+        public SubTopologyDescription(string id, IList<INodeDescription> nodes)
+        {
+            Id = id;
+            Nodes = nodes;
+        }
+    }
+
+    #endregion
+
+    #region NodeDescription
+
+    internal abstract class NodeDescription : INodeDescription
+    {
+        private readonly IList<INodeDescription> next = new List<INodeDescription>();
+        private readonly IList<INodeDescription> previous = new List<INodeDescription>();
+
+        public string Name { get; }
+
+        public IEnumerable<INodeDescription> Next => next;
+
+        public IEnumerable<INodeDescription> Previous => previous;
+
+        public NodeDescription(string name)
+        {
+            Name = name;
+        }
+
+        public void AddPredecessor(INodeDescription node)
+        {
+            if (!previous.Contains(node))
+                previous.Add(node);
+        }
+
+        public void AddSuccessor(INodeDescription node)
+        {
+            if (!next.Contains(node))
+                next.Add(node);
+        }
+
+        public override bool Equals(object obj) => obj is INodeDescription && ((INodeDescription)obj).Equals(this.Name);
+
+        public override int GetHashCode() => Name.GetHashCode();
+    }
+
+    #endregion
+
+    #region SourceNodeDescription
+
+    internal class SourceNodeDescription : NodeDescription, ISourceNodeDescription
+    {
+        public IEnumerable<string> Topics { get; }
+
+        public Type TimestampExtractorType { get; }
+
+        public SourceNodeDescription(string name, string topic) 
+            : base(name)
+        {
+            Topics = new List<string> { topic };
+            TimestampExtractorType = null;
+        }
+
+        public SourceNodeDescription(string name, Type timestampExtractorType)
+            : base(name)
+        {
+            Topics = null;
+            TimestampExtractorType = timestampExtractorType;
+        }
+    }
+
+    #endregion
+
+    #region ProcessorNodeDescription
+
+    internal class ProcessorNodeDescription : NodeDescription, IProcessorNodeDescription
+    {
+        public IEnumerable<string> Stores { get; }
+
+        public ProcessorNodeDescription(string name, IEnumerable<string> stores = null) 
+            : base(name)
+        {
+            Stores = stores;
+        }
+    }
+
+    #endregion
+
+    #region SinkNodeDescription
+
+    internal class SinkNodeDescription : NodeDescription, ISinkNodeDescription
+    {
+        public string Topic { get; }
+
+        public Type TopicNameExtractorType { get; }
+
+        public SinkNodeDescription(string name, string topic) 
+            : base(name)
+        {
+            Topic = topic;
+            TopicNameExtractorType = null;
+        }
+
+        public SinkNodeDescription(string name, Type topicNameExtractorType)
+            : base(name)
+        {
+            Topic = null;
+            TopicNameExtractorType = topicNameExtractorType;
+        }
+    }
+
+    #endregion
+}

--- a/core/Stream/Topology.cs
+++ b/core/Stream/Topology.cs
@@ -23,5 +23,12 @@ namespace Streamiz.Kafka.Net.Stream
         internal Topology()
         {
         }
+
+        /// <summary>
+        /// Returns a description of the specified <see cref="Topology"/>.
+        /// Can using to create a schema about your topolgy.
+        /// </summary>
+        /// <returns>a description of the topology.</returns>
+        public ITopologyDescription Describe() => Builder.Describe();
     }
 }

--- a/core/kafka-stream-core.nuspec
+++ b/core/kafka-stream-core.nuspec
@@ -4,7 +4,7 @@
     <id>Streamiz.Kafka.NET</id>
     <version>$version$</version>
     <title>Streamiz.Kafka.NET</title>
-    <authors>Sylvain Le Gouellec</authors>
+    <authors>@LGouellec</authors>
     <owners>Sylvain Le Gouellec</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>

--- a/core/kafka-stream-core.nuspec
+++ b/core/kafka-stream-core.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package >
+  <metadata>
+    <id>Streamiz.Kafka.NET</id>
+    <version>$version$</version>
+    <title>Streamiz.Kafka.NET</title>
+    <authors>Sylvain Le Gouellec</authors>
+    <owners>Sylvain Le Gouellec</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/LGouellec/kafka-streams-dotnet</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/LGouellec/kafka-streams-dotnet/master/resources/logo-kafka-stream-net.png</iconUrl>
+    <description>.NET Stream Processing Library for Apache Kafka</description>
+    <releaseNotes>https://github.com/LGouellec/kafka-streams-dotnet/releases</releaseNotes>
+    <copyright>Copyright 2020</copyright>
+    <tags>kafka kafka-streams kafka-streams-dotnet event-streaming</tags>
+  </metadata>
+</package>


### PR DESCRIPTION
Adds a `KafkaStream.Store(...)` so that this is possible"

```
builder
   .Table(topic, new StringSerDes(), new ValueAndTimestampSerDes<string>(new StringSerDes()), InMemory<string, ValueAndTimestamp<string>>.As("topics-store")
   .WithCachingDisabled());
[...]
_stream
   .Store("topics-store", QueryableStoreTypes.TimestampedKeyValueStore<string, ValueAndTimestamp<string>>())
   .All()
   .Where(...)
```

only `QueryableStoreTypes.TimestampedKeyValueStore` and `QueryableStoreTypes.KeyValueStore` are supported for now.