### PR TITLE
Permit to follow headers metadata in processing

### DIFF
--- a/core/HeadersMetadata.cs
+++ b/core/HeadersMetadata.cs
@@ -1,0 +1,11 @@
+﻿using Confluent.Kafka;
+using Streamiz.Kafka.Net.Processors;
+
+namespace Streamiz.Kafka.Net
+{
+    public static class HeadersMetadata
+    {
+        public static Headers GetCurrentMetadata()
+            => StreamTask.CurrentHeaders;
+    }
+}

--- a/core/Processors/Internal/TaskManager.cs
+++ b/core/Processors/Internal/TaskManager.cs
@@ -8,6 +8,9 @@ namespace Streamiz.Kafka.Net.Processors.Internal
 {
     internal class TaskManager
     {
+        [ThreadStatic] 
+        internal static StreamTask CurrentTask = null;
+        
         private readonly ILog log = Logger.GetLogger(typeof(TaskManager));
         private readonly InternalTopologyBuilder builder;
         private readonly TaskCreator taskCreator;
@@ -111,10 +114,12 @@ namespace Streamiz.Kafka.Net.Processors.Internal
         {
             foreach (var t in activeTasks)
             {
+                CurrentTask = t.Value;
                 t.Value.Close();
             }
 
             activeTasks.Clear();
+            CurrentTask = null;
 
             foreach (var t in revokedTasks)
             {
@@ -171,6 +176,7 @@ namespace Streamiz.Kafka.Net.Processors.Internal
             {
                 foreach (var t in ActiveTasks)
                 {
+                    CurrentTask = t;
                     if (t.CommitNeeded)
                     {
                         t.Commit();
@@ -189,6 +195,7 @@ namespace Streamiz.Kafka.Net.Processors.Internal
             {
                 try
                 {
+                    CurrentTask = task;
                     if (task.CanProcess(now) && task.Process())
                     {
                         processed++;

--- a/core/StreamConfig.cs
+++ b/core/StreamConfig.cs
@@ -226,6 +226,8 @@ namespace Streamiz.Kafka.Net
         /// </summary>
         long BufferedRecordsPerPartition { get; set; }
 
+        bool FollowHeaders { get; set; }
+
         #endregion
     }
 
@@ -326,6 +328,7 @@ namespace Streamiz.Kafka.Net
         internal static readonly string maxPollRecordsCst = "max.poll.records.ms";
         internal static readonly string maxTaskIdleCst = "max.task.idle.ms";
         internal static readonly string bufferedRecordsPerPartitionCst = "buffered.records.per.partition";
+        internal static readonly string followheadersCst = "follow.headers";
 
         /// <summary>
         /// Default commit interval in milliseconds when exactly once is not enabled
@@ -1782,6 +1785,7 @@ namespace Streamiz.Kafka.Net
             InnerExceptionHandler = (exception) => ExceptionHandlerResponse.FAIL;
             ProductionExceptionHandler = (report) => ExceptionHandlerResponse.FAIL;
             DeserializationExceptionHandler = (context, record, exception) => ExceptionHandlerResponse.FAIL;
+            FollowHeaders = false;
 
             if (properties != null)
             {
@@ -1802,6 +1806,12 @@ namespace Streamiz.Kafka.Net
         #endregion
 
         #region IStreamConfig Impl
+
+        public bool FollowHeaders
+        {
+            get => this[followheadersCst];
+            set => this.AddOrUpdate(followheadersCst, value);
+        }
 
         /// <summary>
         /// The number of threads to execute stream processing.

--- a/samples/sample-stream/Program.cs
+++ b/samples/sample-stream/Program.cs
@@ -15,11 +15,19 @@ namespace sample_stream
         {
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-app";
-            config.BootstrapServers = "localhost:9092";
+            config.BootstrapServers = "localhost:9093";
+            config.FollowHeaders = true;
+            config.NumStreamThreads = 2;
 
             StreamBuilder builder = new StreamBuilder();
-            IKStream<string, string> kStream = builder.Stream<string, string>("test-topic");
-
+            IKStream<string, string> kStream = builder.Stream<string, string>("test");
+            kStream.MapValues((v) =>
+            {
+                var headers = HeadersMetadata.GetCurrentMetadata();
+                if(headers.Count > 0 )
+                    Console.WriteLine("RANDOM : " + BitConverter.ToInt32(headers.GetLastBytes("random")));
+                return v;
+            });
             kStream.Print(Printed<string, string>.ToOut());
 
             Topology t = builder.Build();

--- a/samples/sample-stream/log4net.config
+++ b/samples/sample-stream/log4net.config
@@ -6,7 +6,7 @@
     </layout>
   </appender>
   <root>
-    <level value="DEBUG" />
+    <level value="INFO" />
     <appender-ref ref="ConsoleAppender" />
   </root>
 </log4net>

--- a/test/Producer/Program.cs
+++ b/test/Producer/Program.cs
@@ -7,10 +7,12 @@ namespace Producer
     {
         private static void Main(string[] args)
         {
+            Random rd = new Random(DateTime.Now.Millisecond);
+
             var producerConfig = new ProducerConfig
             {
                 Acks = Acks.All,
-                BootstrapServers = "localhost:29092"
+                BootstrapServers = "localhost:9093"
             };
             var topic = args.Length > 0 ? args[0] : "test";
             var builder = new ProducerBuilder<String, String>(producerConfig);
@@ -22,7 +24,14 @@ namespace Producer
                 while (!s.Contains("exit", StringComparison.InvariantCultureIgnoreCase))
                 {
                     string[] r = s.Split(":");
-                    producer.Produce(topic, new Message<string, string> { Key = r[0], Value = r[1] }, (d) =>
+                    var randomInt = rd.Next(0, 100000);
+                    Headers headers = new Headers();
+                    headers.Add(new Header("random", BitConverter.GetBytes(randomInt)));
+                    producer.Produce(topic, new Message<string, string> { 
+                        Key = r[0],
+                        Value = r[1],
+                        Headers = headers
+                    }, (d) =>
                     {
                         if (d.Status == PersistenceStatus.Persisted)
                         {


### PR DESCRIPTION
Sometimes, you want get headers metadata in DSL API. (Processor API is not available yet !).
That's why this workaround :

Example use-case : 
``` csharp
            var config = new StreamConfig<StringSerDes, StringSerDes>();
            config.ApplicationId = "test-app";
            config.BootstrapServers = "localhost:9092";
            config.FollowHeaders = true;

            StreamBuilder builder = new StreamBuilder();
            IKStream<string, string> kStream = builder.Stream<string, string>("test");
            kStream.MapValues((v) =>
            {
                var headers = HeadersMetadata.GetCurrentMetadata();
                if(headers.Count > 0 )
                    Console.WriteLine("RANDOM : " + BitConverter.ToInt32(headers.GetLastBytes("random")));
                return v;
            });
            kStream.Print(Printed<string, string>.ToOut());

            Topology t = builder.Build();
            KafkaStream stream = new KafkaStream(t, config);

            Console.CancelKeyPress += (o, e) => stream.Dispose();

            await stream.StartAsync();
```

This feature will be available in 1.1.3 release.