### PR TITLE
Prevent repeating exception handling in StreamThread.Run

### DIFF
--- a/core/Processors/StreamThread.cs
+++ b/core/Processors/StreamThread.cs
@@ -284,31 +284,20 @@ namespace Streamiz.Kafka.Net.Processors
 
         private bool TreatException(Exception exception)
         {
-            if (!(exception is DeserializationException) && !(exception is ProductionException))
-            {
-                var response = streamConfig.InnerExceptionHandler(exception);
-                if (response == ExceptionHandlerResponse.FAIL)
-                {
-                    Close(false);
-                    if (ThrowException)
-                        throw new StreamsException(exception);
-                    return true;
-                }
-                else if (response == ExceptionHandlerResponse.CONTINUE)
-                {
-                    return false;
-                }
-                else
-                    return true;
-            }
-            else
+            if (exception is DeserializationException || exception is ProductionException)
             {
                 Close(false);
-                if (ThrowException)
-                    throw new StreamsException(exception);
-
+                if (ThrowException) throw new StreamsException(exception);
                 return true;
             }
+            var response = streamConfig.InnerExceptionHandler(exception);
+            if (response == ExceptionHandlerResponse.FAIL)
+            {
+                Close(false);
+                if (ThrowException) throw new StreamsException(exception);
+                return true;
+            }
+            return response != ExceptionHandlerResponse.CONTINUE;
         }
 
         public void Start(CancellationToken token)


### PR DESCRIPTION
Except fixing the bug of exception loop I made a little refactoring also for code clarity in the method changed. It prevents possible multiple iteration of records as IEnumerable and strictly counts time