### PR TITLE
add subject name stategy to config option.

### DIFF
--- a/core/SchemaRegistryConfig.cs
+++ b/core/SchemaRegistryConfig.cs
@@ -1,5 +1,32 @@
 ﻿namespace Streamiz.Kafka.Net
 {
+
+    /// <summary>
+    ///     Subject name strategy. Refer to: https://www.confluent.io/blog/put-several-event-types-kafka-topic/
+    /// </summary>
+    public enum SubjectNameStrategy
+    {
+        /// <summary>
+        ///     (default): The subject name for message keys is &lt;topic&gt;-key, and &lt;topic&gt;-value for message values.
+        ///     This means that the schemas of all messages in the topic must be compatible with each other.
+        /// </summary>
+        Topic,
+
+        /// <summary>
+        ///     The subject name is the fully-qualified name of the Avro record type of the message.
+        ///     Thus, the schema registry checks the compatibility for a particular record type, regardless of topic.
+        ///     This setting allows any number of different event types in the same topic.
+        /// </summary>
+        Record,
+
+        /// <summary>
+        ///     The subject name is &lt;topic&gt;-&lt;type&gt;, where &lt;topic&gt; is the Kafka topic name, and &lt;type&gt;
+        ///     is the fully-qualified name of the Avro record type of the message. This setting also allows any number of event
+        ///     types in the same topic, and further constrains the compatibility check to the current topic only.
+        /// </summary>
+        TopicRecord
+    }
+
     /// <summary>
     /// Interface schema registry configuration. 
     /// Configure url schema registry, auto register configuration, etc .... for stream application.
@@ -26,5 +53,10 @@
         /// Specifies whether or not the Avro serializer should attempt to auto-register unrecognized schemas with Confluent Schema Registry. default: true
         /// </summary>
         public bool? AutoRegisterSchemas { get; set; }
+
+        /// <summary>
+        /// The subject name strategy to use for schema registration / lookup. Possible values: <see cref="Streamiz.Kafka.Net.SubjectNameStrategy" />
+        /// </summary>
+        public SubjectNameStrategy? SubjectNameStrategy { get; set; }
     }
 }

--- a/core/StreamConfig.cs
+++ b/core/StreamConfig.cs
@@ -319,6 +319,7 @@ namespace Streamiz.Kafka.Net
         internal static readonly string schemaRegistryAutoRegisterCst = "schema.registry.auto.register.schema";
         internal static readonly string schemaRegistryRequestTimeoutMsCst = "schema.registry.request.timeout.ms";
         internal static readonly string schemaRegistryMaxCachedSchemasCst = "schema.registry.max.cached.schemas";
+        internal static readonly string avroSerializerSubjectNameStrategyCst= "avro.serializer.subject.name.strategy";
         internal static readonly string applicatonIdCst = "application.id";
         internal static readonly string clientIdCst = "client.id";
         internal static readonly string numStreamThreadsCst = "num.stream.threads";
@@ -2122,6 +2123,14 @@ namespace Streamiz.Kafka.Net
             set => this.AddOrUpdate(schemaRegistryAutoRegisterCst, value);
         }
 
+        /// <summary>
+        /// The subject name strategy to use for schema registration / lookup. Possible values: <see cref="Streamiz.Kafka.Net.SubjectNameStrategy" />
+        /// </summary>
+        public SubjectNameStrategy? SubjectNameStrategy 
+        { 
+            get => this.ContainsKey(avroSerializerSubjectNameStrategyCst) ? this[avroSerializerSubjectNameStrategyCst] : null;
+            set => this.AddOrUpdate(avroSerializerSubjectNameStrategyCst, value); 
+        }
         #endregion
 
         #region ToString()

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro/SchemaAvroSerDes.cs
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro/SchemaAvroSerDes.cs
@@ -46,7 +46,10 @@ namespace Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro
             {
                 c.AutoRegisterSchemas = config.AutoRegisterSchemas;
             }
-
+            if(config.SubjectNameStrategy.HasValue)
+            {
+                c.SubjectNameStrategy = (Confluent.SchemaRegistry.SubjectNameStrategy)config.SubjectNameStrategy.Value;
+            }
             return c;
         }
 


### PR DESCRIPTION
Now it is possible to select the subject naming strategy for the avro serializar. Topic, Record or TopicRecord.
