### PR TITLE
Fix/global ktable restoration

### DIFF
--- a/core/Mock/ClusterInMemoryTopologyDriver.cs
+++ b/core/Mock/ClusterInMemoryTopologyDriver.cs
@@ -138,7 +138,7 @@ namespace Streamiz.Kafka.Net.Mock
         {
             IsRunning = false;
             threadTopology.Dispose();
-            globalStreamThread.Dispose();
+            globalStreamThread?.Dispose();
             
             foreach(var asyncPipe in asyncPipeOutput)
                 asyncPipe.Dispose();

--- a/core/Mock/ClusterInMemoryTopologyDriver.cs
+++ b/core/Mock/ClusterInMemoryTopologyDriver.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Streamiz.Kafka.Net.Metrics;
+using Streamiz.Kafka.Net.Stream.Internal;
 
 namespace Streamiz.Kafka.Net.Mock
 {
@@ -16,14 +17,17 @@ namespace Streamiz.Kafka.Net.Mock
     {
         private readonly IStreamConfig configuration;
         private readonly IStreamConfig topicConfiguration;
-        private readonly IPipeBuilder pipeBuilder = null;
-        private readonly IThread threadTopology = null;
-        private readonly IKafkaSupplier kafkaSupplier = null;
+        private readonly IPipeBuilder pipeBuilder;
+        private readonly IThread threadTopology;
+        private readonly GlobalStreamThread globalStreamThread;
+        private readonly IKafkaSupplier kafkaSupplier;
         private readonly CancellationToken token;
         private readonly TimeSpan startTimeout;
         private readonly InternalTopologyBuilder internalTopologyBuilder;
         private readonly StreamMetricsRegistry metricsRegistry;
+        private readonly bool hasGlobalTopology;
         private ITopicManager internalTopicManager;
+        private List<IPipeOutput> asyncPipeOutput = new();
 
         public ClusterInMemoryTopologyDriver(string clientId, InternalTopologyBuilder topologyBuilder, IStreamConfig configuration, IStreamConfig topicConfiguration, CancellationToken token)
             : this(clientId, topologyBuilder, configuration, topicConfiguration, TimeSpan.FromSeconds(30), token)
@@ -51,7 +55,9 @@ namespace Streamiz.Kafka.Net.Mock
             
             pipeBuilder = new KafkaPipeBuilder(kafkaSupplier);
 
-            // ONLY FOR CHECK IF TOLOGY IS CORRECT
+            topologyBuilder.RewriteTopology(configuration);
+            
+            // ONLY FOR CHECK IF TOPOLOGY IS CORRECT
             topologyBuilder.BuildTopology();
 
             threadTopology = StreamThread.Create(
@@ -63,6 +69,21 @@ namespace Streamiz.Kafka.Net.Mock
                 kafkaSupplier,
                 kafkaSupplier.GetAdmin(configuration.ToAdminConfig($"{clientId}-admin")),
                 0);
+            
+            ProcessorTopology globalTaskTopology = topologyBuilder.BuildGlobalStateTopology();
+            hasGlobalTopology = globalTaskTopology != null;
+            if (hasGlobalTopology)
+            {
+                string globalThreadId = $"{clientId}-GlobalStreamThread";
+                GlobalStreamThreadFactory globalStreamThreadFactory = new GlobalStreamThreadFactory(
+                    globalTaskTopology,
+                    globalThreadId,
+                    kafkaSupplier.GetGlobalConsumer(configuration.ToGlobalConsumerConfig(globalThreadId)),
+                    configuration,
+                    kafkaSupplier.GetAdmin(configuration.ToAdminConfig(clientId)),
+                    metricsRegistry);
+                globalStreamThread = globalStreamThreadFactory.GetGlobalStreamThread();
+            }
         }
 
         public bool IsRunning { get; private set; }
@@ -109,6 +130,7 @@ namespace Streamiz.Kafka.Net.Mock
         public TestOutputTopic<K, V> CreateOutputTopic<K, V>(string topicName, TimeSpan consumeTimeout, ISerDes<K> keySerdes = null, ISerDes<V> valueSerdes = null)
         {
             var pipeOutput = pipeBuilder.Output(topicName, consumeTimeout, topicConfiguration, token);
+            asyncPipeOutput.Add(pipeOutput);
             return new TestOutputTopic<K, V>(pipeOutput, topicConfiguration, keySerdes, valueSerdes);
         }
 
@@ -116,6 +138,11 @@ namespace Streamiz.Kafka.Net.Mock
         {
             IsRunning = false;
             threadTopology.Dispose();
+            globalStreamThread.Dispose();
+            
+            foreach(var asyncPipe in asyncPipeOutput)
+                asyncPipe.Dispose();
+            
             (kafkaSupplier as MockKafkaSupplier)?.Destroy();
         }
 
@@ -159,6 +186,9 @@ namespace Streamiz.Kafka.Net.Mock
             };
 
             InitializeInternalTopicManager();
+
+            if (globalStreamThread != null)
+                globalStreamThread.Start(token);
 
             threadTopology.Start(token);
             while (!isRunningState)

--- a/core/Mock/Kafka/MockConsumer.cs
+++ b/core/Mock/Kafka/MockConsumer.cs
@@ -40,18 +40,15 @@ namespace Streamiz.Kafka.Net.Mock.Kafka
         public int AddBrokers(string brokers) => 0;
 
         public void Assign(TopicPartition partition)
-        {
-            cluster.Assign(this, new List<TopicPartition> { partition });
-        }
+            => Assign(new List<TopicPartition> {partition});
 
         public void Assign(TopicPartitionOffset partition)
-        {
-            // TODO
-        }
+            => Assign(new List<TopicPartitionOffset> {partition});
 
         public void Assign(IEnumerable<TopicPartitionOffset> partitions)
         {
-            // TODO
+            cluster.Assign(this, partitions);
+            Assignment = partitions.Select(t => t.TopicPartition).ToList();
         }
 
         public void Assign(IEnumerable<TopicPartition> partitions)
@@ -64,6 +61,7 @@ namespace Streamiz.Kafka.Net.Mock.Kafka
         {
             cluster.CloseConsumer(Name);
             Assignment.Clear();
+            Subscription.Clear();
         }
 
         public List<TopicPartitionOffset> Commit()

--- a/core/Mock/Pipes/SyncPipeInput.cs
+++ b/core/Mock/Pipes/SyncPipeInput.cs
@@ -2,17 +2,18 @@
 using Streamiz.Kafka.Net.Crosscutting;
 using Streamiz.Kafka.Net.Processors;
 using System;
+using Streamiz.Kafka.Net.Mock.Sync;
 
 namespace Streamiz.Kafka.Net.Mock.Pipes
 {
     internal class SyncPipeInput : IPipeInput
     {
-        private readonly StreamTask task;
+        private readonly ISyncPublisher publisher;
         private readonly string topic;
 
-        public SyncPipeInput(StreamTask task, string topic)
+        public SyncPipeInput(ISyncPublisher publisher, string topic)
         {
-            this.task = task;
+            this.publisher = publisher;
             this.topic = topic;
         }
 
@@ -26,20 +27,13 @@ namespace Streamiz.Kafka.Net.Mock.Pipes
 
         public void Flush()
         {
-            long now = DateTime.Now.GetMilliseconds();
-            while (task.CanProcess(now))
-                task.Process();
+            publisher.Flush();
             Flushed?.Invoke();
         }
 
         public void Pipe(byte[] key, byte[] value, DateTime timestamp)
         {
-            task.AddRecord(new ConsumeResult<byte[], byte[]>
-            {
-                Topic = topic,
-                TopicPartitionOffset = new TopicPartitionOffset(new TopicPartition(topic, task.Id.Partition), 0),
-                Message = new Message<byte[], byte[]> { Key = key, Value = value, Timestamp = new Timestamp(timestamp) }
-            });
+            publisher.PublishRecord(topic, key, value, timestamp);
         }
     }
 }

--- a/core/Mock/Sync/ISyncPublisher.cs
+++ b/core/Mock/Sync/ISyncPublisher.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Streamiz.Kafka.Net.Mock.Sync
+{
+    internal interface ISyncPublisher
+    {
+        public void PublishRecord(string topic, byte[] key, byte[] value, DateTime timestamp);
+        public void Flush();
+    }
+}

--- a/core/Mock/Sync/SyncPipeBuilder.cs
+++ b/core/Mock/Sync/SyncPipeBuilder.cs
@@ -2,28 +2,88 @@
 using Streamiz.Kafka.Net.Processors;
 using System;
 using System.Threading;
+using Confluent.Kafka;
+using Streamiz.Kafka.Net.Crosscutting;
+using Streamiz.Kafka.Net.Processors.Internal;
 
 namespace Streamiz.Kafka.Net.Mock.Sync
 {
     internal class SyncPipeBuilder : IPipeBuilder
     {
-        private readonly StreamTask task;
+        private class StreamTaskPublisher : ISyncPublisher
+        {
+            private readonly StreamTask task;
+
+            public StreamTaskPublisher(StreamTask task)
+            {
+                this.task = task;
+            }
+
+            private int offset = 0;
+
+            public void PublishRecord(string topic, byte[] key, byte[] value, DateTime timestamp)
+                => task.AddRecord(new ConsumeResult<byte[], byte[]>
+                {
+                    Topic = topic,
+                    TopicPartitionOffset = new TopicPartitionOffset(new TopicPartition(topic, task.Id.Partition), offset++),
+                    Message = new Message<byte[], byte[]> { Key = key, Value = value, Timestamp = new Timestamp(timestamp) }
+                });
+
+            public void Flush()
+            {
+                long now = DateTime.Now.GetMilliseconds();
+                while (task.CanProcess(now))
+                    task.Process();
+            }
+        }
+
+        private class GlobalTaskPublisher : ISyncPublisher
+        {
+            private readonly GlobalStateUpdateTask globalTask;
+            private int offset = 0;
+            
+            public GlobalTaskPublisher(GlobalStateUpdateTask globalTask)
+            {
+                this.globalTask = globalTask;
+            }
+
+            public void PublishRecord(string topic, byte[] key, byte[] value, DateTime timestamp)
+            {
+                globalTask.Update(new ConsumeResult<byte[], byte[]>
+                {
+                    Topic = topic,
+                    TopicPartitionOffset = new TopicPartitionOffset(new TopicPartition(topic, 0), offset++),
+                    Message = new Message<byte[], byte[]> { Key = key, Value = value, Timestamp = new Timestamp(timestamp) }
+                });
+            }
+
+            public void Flush()
+            {
+                globalTask.FlushState();
+            }
+        }
+        
+        private readonly ISyncPublisher publisher;
         private readonly SyncProducer mockProducer;
 
         public SyncPipeBuilder(StreamTask task)
         {
-            this.task = task;
+            publisher = new StreamTaskPublisher(task);
+        }
+        
+        public SyncPipeBuilder(GlobalStateUpdateTask globalTask)
+        {
+            publisher = new GlobalTaskPublisher(globalTask);
         }
 
-        public SyncPipeBuilder(StreamTask task, SyncProducer mockProducer)
+        public SyncPipeBuilder(SyncProducer mockProducer)
         {
             this.mockProducer = mockProducer;
-            this.task = task;
         }
 
         public IPipeInput Input(string topic, IStreamConfig configuration)
         {
-            return new SyncPipeInput(task, topic);
+            return new SyncPipeInput(publisher, topic);
         }
 
         public IPipeOutput Output(string topic, TimeSpan consumeTimeout, IStreamConfig configuration, CancellationToken token = default)

--- a/core/Mock/TopologyTestDriver.cs
+++ b/core/Mock/TopologyTestDriver.cs
@@ -78,7 +78,7 @@ namespace Streamiz.Kafka.Net.Mock
             ASYNC_CLUSTER_IN_MEMORY
         }
 
-        private readonly CancellationTokenSource tokenSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource tokenSource = new();
         private readonly InternalTopologyBuilder topologyBuilder;
         private readonly IStreamConfig configuration;
         private readonly IStreamConfig topicConfiguration;

--- a/core/Processors/AbstractTask.cs
+++ b/core/Processors/AbstractTask.cs
@@ -112,7 +112,7 @@ namespace Streamiz.Kafka.Net.Processors
 
         protected void RegisterStateStores()
         {
-            if (!Topology.StateStores.Any() && !Topology.GlobalStateStores.Any())
+            if (!Topology.StateStores.Any())
             {
                 return;
             }
@@ -120,13 +120,6 @@ namespace Streamiz.Kafka.Net.Processors
             log.LogDebug("{LogPrefix}Initializing state stores", logPrefix);
 
             foreach (var kv in Topology.StateStores)
-            {
-                var store = kv.Value;
-                log.LogDebug("{LogPrefix}Initializing store {Key}", logPrefix, kv.Key);
-                store.Init(Context, store);
-            }
-
-            foreach (var kv in Topology.GlobalStateStores.Where(k => !Topology.StateStores.ContainsKey(k.Key)))
             {
                 var store = kv.Value;
                 log.LogDebug("{LogPrefix}Initializing store {Key}", logPrefix, kv.Key);

--- a/core/Processors/AbstractTask.cs
+++ b/core/Processors/AbstractTask.cs
@@ -20,7 +20,7 @@ namespace Streamiz.Kafka.Net.Processors
         protected bool taskInitialized;
         protected bool commitNeeded = false;
         protected bool commitRequested = false;
-        protected IStateManager stateMgr;
+        protected ProcessorStateManager stateMgr;
         protected ILogger log;
         protected readonly string logPrefix = "";
         protected TaskState state = TaskState.CREATED;
@@ -112,7 +112,7 @@ namespace Streamiz.Kafka.Net.Processors
 
         protected void RegisterStateStores()
         {
-            if (!Topology.StateStores.Any())
+            if (!Topology.StateStores.Any() && !Topology.GlobalStateStores.Any())
             {
                 return;
             }
@@ -125,6 +125,8 @@ namespace Streamiz.Kafka.Net.Processors
                 log.LogDebug("{LogPrefix}Initializing store {Key}", logPrefix, kv.Key);
                 store.Init(Context, store);
             }
+
+            stateMgr.RegisterGlobalStateStores(Topology.GlobalStateStores);
         }
 
         protected virtual void FlushState()

--- a/core/Processors/GlobalStreamThread.cs
+++ b/core/Processors/GlobalStreamThread.cs
@@ -72,7 +72,9 @@ namespace Streamiz.Kafka.Net.Processors
             {
                 try
                 {
+                    globalConsumer.Unassign();
                     globalConsumer.Close();
+                    globalConsumer.Dispose();
                 }
                 catch (Exception e)
                 {
@@ -151,15 +153,10 @@ namespace Streamiz.Kafka.Net.Processors
             {
                 stateConsumer = InitializeStateConsumer();
             }
-            catch
-            {
-                SetState(GlobalThreadState.PENDING_SHUTDOWN);
-                SetState(GlobalThreadState.DEAD);
-
+            catch(Exception e){
+                
                 log.LogWarning(
-                    "{LogPrefix}Error happened during initialization of the global state store; this thread has shutdown",
-                    logPrefix);
-
+                    $"{logPrefix}Error happened during initialization of the global state store; this thread has shutdown : {e}");
                 throw;
             }
 

--- a/core/Processors/Internal/GlobalStateManager.cs
+++ b/core/Processors/Internal/GlobalStateManager.cs
@@ -224,7 +224,6 @@ namespace Streamiz.Kafka.Net.Processors.Internal
         {
             foreach (var topicPartition in topicPartitions)
             {
-                globalConsumer.Assign(topicPartition.ToSingle());
                 long offset, checkpoint, highWM;
                 
                 if (ChangelogOffsets.ContainsKey(topicPartition)) 
@@ -232,7 +231,7 @@ namespace Streamiz.Kafka.Net.Processors.Internal
                 else
                     checkpoint = Offset.Beginning.Value;
                 
-                globalConsumer.Seek(new TopicPartitionOffset(topicPartition, new Offset(checkpoint)));
+                globalConsumer.Assign((new TopicPartitionOffset(topicPartition, new Offset(checkpoint))).ToSingle());
                 offset = checkpoint;
                 highWM = highWatermarks[topicPartition].Item2;
 

--- a/core/Processors/Internal/GlobalStateManager.cs
+++ b/core/Processors/Internal/GlobalStateManager.cs
@@ -237,6 +237,9 @@ namespace Streamiz.Kafka.Net.Processors.Internal
 
                 while (offset < highWM - 1)
                 {
+                    if (offset == Offset.Beginning && highWM == 0) // no message into local and topics;
+                        break;
+                    
                     var records = globalConsumer.ConsumeRecords(TimeSpan.FromMilliseconds(config.PollMs),
                         config.MaxPollRestoringRecords).ToList();
 

--- a/core/Processors/Internal/ProcessorStateManager.cs
+++ b/core/Processors/Internal/ProcessorStateManager.cs
@@ -148,9 +148,10 @@ namespace Streamiz.Kafka.Net.Processors.Internal
         public IStateStore GetStore(string name)
         {
             if (registeredStores.ContainsKey(name))
-            {
                 return registeredStores[name].Store;
-            }
+
+            if (globalStateStores.ContainsKey(name))
+                return globalStateStores[name];
 
             return null;
         }

--- a/samples/sample-stream/Program.cs
+++ b/samples/sample-stream/Program.cs
@@ -40,7 +40,9 @@ namespace sample_stream
 
             StreamBuilder builder = new StreamBuilder();
             
-            /*builder.Stream<string, string>("input")
+            var table = builder.GlobalTable<string, string>("topic");
+            
+            builder.Stream<string, string>("input")
                 .GroupBy((k,v) => v)
                 .Count()
                 .ToStream()
@@ -51,12 +53,6 @@ namespace sample_stream
             
             Console.CancelKeyPress += (o, e) => stream.Dispose();
 
-            await stream.StartAsync();*/
-            var table = builder.GlobalTable<string, string>("topic");
-
-            Topology t = builder.Build();
-
-            KafkaStream stream = new KafkaStream(t, config);
             await stream.StartAsync();
         }
     }

--- a/samples/sample-stream/Program.cs
+++ b/samples/sample-stream/Program.cs
@@ -40,7 +40,7 @@ namespace sample_stream
 
             StreamBuilder builder = new StreamBuilder();
             
-            builder.Stream<string, string>("input")
+            /*builder.Stream<string, string>("input")
                 .GroupBy((k,v) => v)
                 .Count()
                 .ToStream()
@@ -51,6 +51,12 @@ namespace sample_stream
             
             Console.CancelKeyPress += (o, e) => stream.Dispose();
 
+            await stream.StartAsync();*/
+            var table = builder.GlobalTable<string, string>("topic");
+
+            Topology t = builder.Build();
+
+            KafkaStream stream = new KafkaStream(t, config);
             await stream.StartAsync();
         }
     }


### PR DESCRIPTION
# Fix #129

## Issue
Global ktable restoration phase used before :
``` csharp
consumer.Assign(...);
consumer.Seek(...);
````

## Fix
Following this [issue](https://github.com/confluentinc/confluent-kafka-dotnet/issues/1061), 
``` csharp
globalConsumer.Assign((new TopicPartitionOffset(topicPartition, new Offset(checkpoint))).ToSingle());
````
