### PR TITLE
upgrade Confluent.Kafka to 1.9.2

### DIFF
--- a/core/Mock/Kafka/MockAdminClient.cs
+++ b/core/Mock/Kafka/MockAdminClient.cs
@@ -37,6 +37,11 @@ namespace Streamiz.Kafka.Net.Mock.Kafka
             throw new NotImplementedException();
         }
 
+        public Task DeleteGroupsAsync(IList<string> groups, DeleteGroupsOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task CreateTopicsAsync(IEnumerable<TopicSpecification> topics, CreateTopicsOptions options = null)
         {
             return Task.Run(() =>
@@ -55,6 +60,21 @@ namespace Streamiz.Kafka.Net.Mock.Kafka
         {
             var result = cluster.DeleteRecords(topicPartitionOffsets);
             return Task.FromResult(result);
+        }
+
+        public Task CreateAclsAsync(IEnumerable<AclBinding> aclBindings, CreateAclsOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<DescribeAclsResult> DescribeAclsAsync(AclBindingFilter aclBindingFilter, DescribeAclsOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<List<DeleteAclsResult>> DeleteAclsAsync(IEnumerable<AclBindingFilter> aclBindingFilters, DeleteAclsOptions options = null)
+        {
+            throw new NotImplementedException();
         }
 
         public Task DeleteTopicsAsync(IEnumerable<string> topics, DeleteTopicsOptions options = null)

--- a/core/Mock/Sync/SyncAdminClient.cs
+++ b/core/Mock/Sync/SyncAdminClient.cs
@@ -40,6 +40,11 @@ namespace Streamiz.Kafka.Net.Mock.Sync
             throw new NotImplementedException();
         }
 
+        public Task DeleteGroupsAsync(IList<string> groups, DeleteGroupsOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task CreateTopicsAsync(IEnumerable<TopicSpecification> topics, CreateTopicsOptions options = null)
         {
             return Task.Run(() =>
@@ -50,6 +55,21 @@ namespace Streamiz.Kafka.Net.Mock.Sync
         }
 
         public Task<List<DeleteRecordsResult>> DeleteRecordsAsync(IEnumerable<TopicPartitionOffset> topicPartitionOffsets, DeleteRecordsOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task CreateAclsAsync(IEnumerable<AclBinding> aclBindings, CreateAclsOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<DescribeAclsResult> DescribeAclsAsync(AclBindingFilter aclBindingFilter, DescribeAclsOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<List<DeleteAclsResult>> DeleteAclsAsync(IEnumerable<AclBindingFilter> aclBindingFilters, DeleteAclsOptions options = null)
         {
             throw new NotImplementedException();
         }

--- a/core/Streamiz.Kafka.Net.csproj
+++ b/core/Streamiz.Kafka.Net.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RocksDB" Version="7.2.2.30179" />
-    <PackageReference Include="Confluent.Kafka" Version="1.9.0" />
+    <PackageReference Include="Confluent.Kafka" Version="1.9.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro.csproj
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.9.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.2" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Json/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Json.csproj
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Json/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Json.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="1.9.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.2" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="1.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Protobuf/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Protobuf.csproj
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Protobuf/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Protobuf.csproj
@@ -31,8 +31,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.9.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.2" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.csproj
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# The reason behind that PR:
Add Apple silicon support.

# Details
The Apple silicon was not supported till Confluent.Kafka version 1.9.1.

Issue: https://github.com/LGouellec/kafka-streams-dotnet/issues/167

Root cause: 
- https://github.com/confluentinc/confluent-kafka-dotnet/issues/1769
- https://github.com/confluentinc/confluent-kafka-dotnet/issues/1707

Upgrading to 1.9.2 adds Apple silicon support to the library.