### PR TITLE
fix #173

### DIFF
--- a/core/KafkaStream.cs
+++ b/core/KafkaStream.cs
@@ -275,8 +275,7 @@ namespace Streamiz.Kafka.Net
         /// <param name="configuration">configuration about this stream</param>
         public KafkaStream(Topology topology, IStreamConfig configuration)
             : this(topology, configuration, new DefaultKafkaClientSupplier(new KafkaLoggerAdapter(configuration), configuration))
-        {
-        }
+        { }
 
         /// <summary>
         /// Create a <see cref="KafkaStream"/> instance with your own <see cref="IKafkaSupplier" />

--- a/core/Processors/StreamThread.cs
+++ b/core/Processors/StreamThread.cs
@@ -21,28 +21,28 @@ namespace Streamiz.Kafka.Net.Processors
 
         public static string GetTaskProducerClientId(string threadClientId, TaskId taskId)
         {
-            return threadClientId + "-" + taskId + "-producer";
+            return threadClientId + "-" + taskId + "-streamiz-producer";
         }
 
         public static string GetThreadProducerClientId(string threadClientId)
         {
-            return threadClientId + "-producer";
+            return threadClientId + "-streamiz-producer";
         }
 
         public static string GetConsumerClientId(string threadClientId)
         {
-            return threadClientId + "-consumer";
+            return threadClientId + "-streamiz-consumer";
         }
 
         public static string GetRestoreConsumerClientId(string threadClientId)
         {
-            return threadClientId + "-restore-consumer";
+            return threadClientId + "-streamiz-restore-consumer";
         }
 
         // currently admin client is shared among all threads
         public static string GetSharedAdminClientId(string clientId)
         {
-            return clientId + "-admin";
+            return clientId + "-streamiz-admin";
         }
 
         internal static IThread Create(string threadId, string clientId, InternalTopologyBuilder builder,

--- a/core/State/InMemory/InMemoryKeyValueBytesStoreSupplier.cs
+++ b/core/State/InMemory/InMemoryKeyValueBytesStoreSupplier.cs
@@ -26,7 +26,7 @@ namespace Streamiz.Kafka.Net.State.InMemory
         /// <summary>
         /// Name of this state store supplier. This must be a valid Kafka topic name; valid characters are ASCII alphanumerics, '.', '_' and '-'.
         /// </summary>
-        public string Name { get; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Return a new <see cref="IStateStore"/> instance.

--- a/core/State/InMemory/InMemoryWindowStoreSupplier.cs
+++ b/core/State/InMemory/InMemoryWindowStoreSupplier.cs
@@ -9,8 +9,6 @@ namespace Streamiz.Kafka.Net.State.InMemory
     /// </summary>
     public class InMemoryWindowStoreSupplier : IWindowBytesStoreSupplier
     {
-        private readonly TimeSpan retention;
-
         /// <summary>
         /// Constructor 
         /// </summary>
@@ -20,7 +18,7 @@ namespace Streamiz.Kafka.Net.State.InMemory
         public InMemoryWindowStoreSupplier(string storeName, TimeSpan retention, long? size)
         {
             Name = storeName;
-            this.retention = retention;
+            Retention = (long) retention.TotalMilliseconds;
             WindowSize = size;
         }
         
@@ -32,7 +30,7 @@ namespace Streamiz.Kafka.Net.State.InMemory
         /// <summary>
         /// Name of state store
         /// </summary>
-        public string Name { get; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Window size of state store
@@ -42,14 +40,14 @@ namespace Streamiz.Kafka.Net.State.InMemory
         /// <summary>
         /// Retention period of state store
         /// </summary>
-        public long Retention => (long)retention.TotalMilliseconds;
+        public long Retention { get; set; }
 
         /// <summary>
         /// Return a new <see cref="IWindowStore{K, V}"/> instance.
         /// </summary>
         /// <returns>Return a new <see cref="IWindowStore{K, V}"/> instance.</returns>
         public IWindowStore<Bytes, byte[]> Get()
-            => new InMemoryWindowStore(Name, retention, WindowSize.Value);
+            => new InMemoryWindowStore(Name, TimeSpan.FromMilliseconds(Retention), WindowSize.Value);
 
     }
 }

--- a/core/State/RocksDb/RocksDbKeyValueBytesStoreSupplier.cs
+++ b/core/State/RocksDb/RocksDbKeyValueBytesStoreSupplier.cs
@@ -25,7 +25,7 @@ namespace Streamiz.Kafka.Net.State.RocksDb
         /// <summary>
         /// State store name
         /// </summary>
-        public string Name { get; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Build the rocksdb state store.

--- a/core/State/RocksDb/RocksDbWindowBytesStoreSupplier.cs
+++ b/core/State/RocksDb/RocksDbWindowBytesStoreSupplier.cs
@@ -10,7 +10,6 @@ namespace Streamiz.Kafka.Net.State.RocksDb
     /// </summary>
     public class RocksDbWindowBytesStoreSupplier : IWindowBytesStoreSupplier
     {
-        private readonly TimeSpan retention;
         private readonly long segmentInterval;
 
         /// <summary>
@@ -27,7 +26,7 @@ namespace Streamiz.Kafka.Net.State.RocksDb
             long? size)
         {
             Name = storeName;
-            this.retention = retention;
+            Retention = (long)retention.TotalMilliseconds;
             this.segmentInterval = segmentInterval;
             WindowSize = size;
         }
@@ -45,12 +44,12 @@ namespace Streamiz.Kafka.Net.State.RocksDb
         /// <summary>
         /// Retention of the state store
         /// </summary>
-        public long Retention => (long)retention.TotalMilliseconds;
+        public long Retention { get; set; }
 
         /// <summary>
         /// State store name
         /// </summary>
-        public string Name { get; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Build the rocksdb state store.

--- a/core/State/Supplier/IStoreSupplier.cs
+++ b/core/State/Supplier/IStoreSupplier.cs
@@ -13,7 +13,7 @@ namespace Streamiz.Kafka.Net.State.Supplier
         /// Return the name of this state store supplier.
         /// This must be a valid Kafka topic name; valid characters are ASCII alphanumerics, '.', '_' and '-'.
         /// </summary>
-        string Name { get; }
+        string Name { get; set; }
 
         /// <summary>
         /// Return a new <see cref="IStateStore"/> instance of type <typeparamref name="T"/>.

--- a/core/State/Supplier/IWindowBytesStoreSupplier.cs
+++ b/core/State/Supplier/IWindowBytesStoreSupplier.cs
@@ -21,6 +21,6 @@ namespace Streamiz.Kafka.Net.State.Supplier
         /// <summary>
         /// The time period for which the <see cref="IWindowStore{K, V}"/> will retain historic data.
         /// </summary>
-        public long Retention { get; }
+        public long Retention { get; set; }
     }
 }

--- a/core/Stream/Internal/GroupedStreamAggregateBuilder.cs
+++ b/core/Stream/Internal/GroupedStreamAggregateBuilder.cs
@@ -90,7 +90,8 @@ namespace Streamiz.Kafka.Net.Stream.Internal
         {
             if (repartitionRequired)
             {
-                (string sourceName, RepartitionNode<K,V> repartNode) = KStream<K, V>.CreateRepartitionSource(grouped.Named ?? storeBuilder.Name, grouped.Key, grouped.Value, builder);
+                string suffix = grouped.Named ?? storeBuilder.Name;
+                (string sourceName, RepartitionNode<K,V> repartNode) = KStream<K, V>.CreateRepartitionSource(suffix, grouped.Key, grouped.Value, builder);
 
                 if (repartitionNode == null || grouped.Named == null)
                     repartitionNode = repartNode;

--- a/core/Table/Materialized.cs
+++ b/core/Table/Materialized.cs
@@ -40,7 +40,7 @@ namespace Streamiz.Kafka.Net.Table
         /// <summary>
         /// Retention time
         /// </summary>
-        protected TimeSpan retention;
+        private TimeSpan retention;
 
         #region Ctor
 
@@ -49,7 +49,7 @@ namespace Streamiz.Kafka.Net.Table
         /// </summary>
         /// <param name="storeName">State store name for query it</param>
         /// <param name="storeSupplier">Supplier use to build the state store</param>
-        internal Materialized(string storeName, IStoreSupplier<S> storeSupplier)
+        protected Materialized(string storeName, IStoreSupplier<S> storeSupplier)
         {
             this.storeName = storeName;
             StoreSupplier = storeSupplier;
@@ -60,7 +60,7 @@ namespace Streamiz.Kafka.Net.Table
         /// Protected constructor with store supplier
         /// </summary>
         /// <param name="storeSupplier">Supplier use to build the state store</param>
-        internal Materialized(IStoreSupplier<S> storeSupplier)
+        private Materialized(IStoreSupplier<S> storeSupplier)
             : this(null, storeSupplier)
         {
         }
@@ -69,28 +69,11 @@ namespace Streamiz.Kafka.Net.Table
         /// Protected constructor with state store name
         /// </summary>
         /// <param name="storeName">State store name for query it</param>
-        internal Materialized(string storeName)
+        private Materialized(string storeName)
             : this(storeName, null)
         {
         }
-
-        /// <summary>
-        /// Copy constructor
-        /// </summary>
-        /// <param name="materialized">Materialized to copy</param>
-        protected Materialized(Materialized<K, V, S> materialized)
-             : this(materialized.StoreName, materialized.StoreSupplier)
-        {
-            StoreSupplier = materialized.StoreSupplier;
-            storeName = materialized.storeName;
-            KeySerdes = materialized.KeySerdes;
-            ValueSerdes = materialized.ValueSerdes;
-            LoggingEnabled = materialized.LoggingEnabled;
-            CachingEnabled = materialized.CachingEnabled;
-            TopicConfig = materialized.TopicConfig;
-            retention = materialized.retention;
-        }
-
+        
         #endregion
 
         #region Static
@@ -121,18 +104,18 @@ namespace Streamiz.Kafka.Net.Table
             return m;
         }
 
-        /// <summary>
-        /// Materialize a <see cref="ISessionStore{K, AGG}"/> using the provided <see cref="ISessionBytesStoreSupplier"/>
-        /// Important: Custom subclasses are allowed here, but they should respect the retention contract:
-        /// Session stores are required to retain windows at least as long as (session inactivity gap + session grace period).
-        /// </summary>
-        /// <param name="supplier">the <see cref="ISessionBytesStoreSupplier"/> used to materialize the store</param>
-        /// <returns>a new <see cref="Materialized{K, V, S}"/> instance with the given supplier</returns>
-        public static Materialized<K, V, ISessionStore<Bytes, byte[]>> Create(ISessionBytesStoreSupplier supplier)
-        {
-            var m = new Materialized<K, V, ISessionStore<Bytes, byte[]>>(supplier);
-            return m;
-        }
+        // /// <summary>
+        // /// Materialize a <see cref="ISessionStore{K, AGG}"/> using the provided <see cref="ISessionBytesStoreSupplier"/>
+        // /// Important: Custom subclasses are allowed here, but they should respect the retention contract:
+        // /// Session stores are required to retain windows at least as long as (session inactivity gap + session grace period).
+        // /// </summary>
+        // /// <param name="supplier">the <see cref="ISessionBytesStoreSupplier"/> used to materialize the store</param>
+        // /// <returns>a new <see cref="Materialized{K, V, S}"/> instance with the given supplier</returns>
+        // public static Materialized<K, V, ISessionStore<Bytes, byte[]>> Create(ISessionBytesStoreSupplier supplier)
+        // {
+        //     var m = new Materialized<K, V, ISessionStore<Bytes, byte[]>>(supplier);
+        //     return m;
+        // }
 
         /// <summary>
         /// Materialize a <see cref="IKeyValueStore{K, V}"/> using the provided <see cref="IKeyValueBytesStoreSupplier"/>
@@ -186,21 +169,21 @@ namespace Streamiz.Kafka.Net.Table
             return Create(supplier).WithKeySerdes(new KS()).WithValueSerdes(new VS());
         }
 
-        /// <summary>
-        /// Materialize a <see cref="ISessionStore{K, AGG}"/> using the provided <see cref="ISessionBytesStoreSupplier"/>
-        /// Important: Custom subclasses are allowed here, but they should respect the retention contract:
-        /// Session stores are required to retain windows at least as long as (session inactivity gap + session grace period).
-        /// </summary>
-        /// <typeparam name="KS">New serializer for <typeparamref name="K"/> type</typeparam>
-        /// <typeparam name="VS">New serializer for <typeparamref name="V"/> type</typeparam>
-        /// <param name="supplier">the <see cref="ISessionBytesStoreSupplier"/> used to materialize the store</param>
-        /// <returns>a new <see cref="Materialized{K, V, S}"/> instance with the given supplier</returns>
-        public static Materialized<K, V, ISessionStore<Bytes, byte[]>> Create<KS, VS>(ISessionBytesStoreSupplier supplier)
-            where KS : ISerDes<K>, new()
-            where VS : ISerDes<V>, new()
-        {
-            return Create(supplier).WithKeySerdes(new KS()).WithValueSerdes(new VS());
-        }
+        // /// <summary>
+        // /// Materialize a <see cref="ISessionStore{K, AGG}"/> using the provided <see cref="ISessionBytesStoreSupplier"/>
+        // /// Important: Custom subclasses are allowed here, but they should respect the retention contract:
+        // /// Session stores are required to retain windows at least as long as (session inactivity gap + session grace period).
+        // /// </summary>
+        // /// <typeparam name="KS">New serializer for <typeparamref name="K"/> type</typeparam>
+        // /// <typeparam name="VS">New serializer for <typeparamref name="V"/> type</typeparam>
+        // /// <param name="supplier">the <see cref="ISessionBytesStoreSupplier"/> used to materialize the store</param>
+        // /// <returns>a new <see cref="Materialized{K, V, S}"/> instance with the given supplier</returns>
+        // public static Materialized<K, V, ISessionStore<Bytes, byte[]>> Create<KS, VS>(ISessionBytesStoreSupplier supplier)
+        //     where KS : ISerDes<K>, new()
+        //     where VS : ISerDes<V>, new()
+        // {
+        //     return Create(supplier).WithKeySerdes(new KS()).WithValueSerdes(new VS());
+        // }
 
         /// <summary>
         /// Materialize a <see cref="IKeyValueStore{K, V}"/> using the provided <see cref="IKeyValueBytesStoreSupplier"/>

--- a/samples/sample-micro-service/Service/StreamizService.cs
+++ b/samples/sample-micro-service/Service/StreamizService.cs
@@ -23,7 +23,7 @@ namespace sample_micro_service.Service
             StreamBuilder builder = new StreamBuilder();
 
             builder
-                .Table("table", RocksDb<string, string>.As("table-store").WithLoggingEnabled())
+                .Table("table", RocksDb.As<string, string>("table-store"))
                 .ToStream()
                 .Print(Printed<string, string>.ToOut());
 

--- a/samples/sample-stream-registry/Program.cs
+++ b/samples/sample-stream-registry/Program.cs
@@ -29,7 +29,7 @@ namespace sample_stream_registry
             var table = builder.Table("product",
                                 new Int32SerDes(),
                                 new SchemaAvroSerDes<Product>(),
-                                InMemory<int, Product>.As("product-store"));
+                                InMemory.As<int, Product>("product-store"));
 
             var orders = builder.Stream<int, Order, Int32SerDes, SchemaAvroSerDes<Order>>("orders");
             

--- a/samples/sample-stream/Program.cs
+++ b/samples/sample-stream/Program.cs
@@ -3,13 +3,11 @@ using Streamiz.Kafka.Net;
 using Streamiz.Kafka.Net.SerDes;
 using System;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Streamiz.Kafka.Net.Metrics;
-using Streamiz.Kafka.Net.Metrics.OpenTelemetry;
 using Streamiz.Kafka.Net.Metrics.Prometheus;
 using Streamiz.Kafka.Net.Table;
-using Streamiz.Kafka.Net.Stream;
 
 namespace sample_stream
 {

--- a/samples/sample-stream/Program.cs
+++ b/samples/sample-stream/Program.cs
@@ -37,15 +37,12 @@ namespace sample_stream
             config.MetricsRecording = MetricsRecordingLevel.DEBUG;
             config.UsePrometheusReporter(9090);
 
-            var m1 = InMemory.As<string, string>("store");
-            var m2 = InMemory<string, string>.Create("store");
-            
             StreamBuilder builder = new StreamBuilder();
             builder.Stream<string, string>("words")
                 .FlatMapValues((v) => v.Split(" "))
                 .SelectKey((k, v) => v)
                 .GroupByKey()
-                .Count(RocksDb<string, long>.Create<StringSerDes, Int64SerDes>("count-store"));
+                .Count(RocksDb.As<string, long, StringSerDes, Int64SerDes>("count-store"));
             
             Topology t = builder.Build();
             KafkaStream stream = new KafkaStream(t, config);

--- a/samples/sample-stream/Program.cs
+++ b/samples/sample-stream/Program.cs
@@ -43,7 +43,7 @@ namespace sample_stream
                 .SelectKey((k, v) => v)
                 .GroupByKey()
                 .Count(RocksDb.As<string, long, StringSerDes, Int64SerDes>("count-store"));
-            
+
             Topology t = builder.Build();
             KafkaStream stream = new KafkaStream(t, config);
             

--- a/samples/sample-test-driver/Program.cs
+++ b/samples/sample-test-driver/Program.cs
@@ -24,7 +24,7 @@ namespace sample_test_driver
                             .Stream<string, string>("test")
                             .GroupByKey()
                             .WindowedBy(TumblingWindowOptions.Of(TimeSpan.FromSeconds(10)))
-                            .Count(InMemoryWindows<string, long>.As("count-store"));
+                            .Count(InMemoryWindows.As<string, long>("count-store"));
 
             Topology t = builder.Build();
 

--- a/test/Streamiz.Kafka.Net.Tests/Private/InternalTopologyBuilderTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Private/InternalTopologyBuilderTests.cs
@@ -13,7 +13,7 @@ namespace Streamiz.Kafka.Net.Tests.Private
 
             var builder = new StreamBuilder();
 
-            var inmemory = InMemory<string, string>.As("table-source");
+            var inmemory = InMemory.As<string, string>("table-source");
             inmemory.WithLoggingEnabled(null);
             builder.Table("source", inmemory);
 

--- a/test/Streamiz.Kafka.Net.Tests/Private/StreamTaskTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Private/StreamTaskTests.cs
@@ -221,7 +221,7 @@ namespace Streamiz.Kafka.Net.Tests.Private
             var serdes = new StringSerDes();
             var builder = new StreamBuilder();
 
-            builder.Table<string, string>("topic", InMemory<string, string>.As("store").WithLoggingDisabled())
+            builder.Table<string, string>("topic", InMemory.As<string, string>("store").WithLoggingDisabled())
                 .MapValues((k, v) => v.ToUpper())
                 .ToStream()
                 .To("topic2");
@@ -328,7 +328,7 @@ namespace Streamiz.Kafka.Net.Tests.Private
             var serdes = new StringSerDes();
             var builder = new StreamBuilder();
 
-            var table = builder.Table("topic", RocksDb<string, string>.As("store").WithLoggingEnabled());
+            var table = builder.Table("topic", RocksDb.As<string, string>("store").WithLoggingEnabled());
 
             TaskId id = new TaskId {Id = 0, Partition = 0};
             var topology = builder.Build();

--- a/test/Streamiz.Kafka.Net.Tests/Private/StreamThreadAssigmentTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Private/StreamThreadAssigmentTests.cs
@@ -107,21 +107,6 @@ namespace Streamiz.Kafka.Net.Tests.Private
                 : base(storeName, storeSupplier)
             {
             }
-
-            public StoreThrowException(IStoreSupplier<IKeyValueStore<Bytes, byte[]>> storeSupplier) 
-                : base(storeSupplier)
-            {
-            }
-
-            public StoreThrowException(string storeName) 
-                : base(storeName)
-            {
-            }
-
-            public StoreThrowException(Materialized<string, string, IKeyValueStore<Bytes, byte[]>> materialized) 
-                : base(materialized)
-            {
-            }
         }
 
         private readonly CancellationTokenSource token1 = new System.Threading.CancellationTokenSource();

--- a/test/Streamiz.Kafka.Net.Tests/Private/StreamThreadAssigmentTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Private/StreamThreadAssigmentTests.cs
@@ -22,7 +22,7 @@ namespace Streamiz.Kafka.Net.Tests.Private
     {
         private class StoreThrowExceptionStore : IKeyValueStore<Bytes, byte[]>
         {
-            public string Name { get; }
+            public string Name { get; set; }
             public bool Persistent { get; }
             public bool IsOpen { get; }
             public void Init(ProcessorContext context, IStateStore root)
@@ -93,7 +93,7 @@ namespace Streamiz.Kafka.Net.Tests.Private
 
         private class StoreThrowExceptionSupplier : IKeyValueBytesStoreSupplier
         {
-            public string Name => "test";
+            public string Name { get; set; } = "test";
 
             public IKeyValueStore<Bytes, byte[]> Get()
                 => new StoreThrowExceptionStore();

--- a/test/Streamiz.Kafka.Net.Tests/Private/StreamThreadRestoreInMemoryTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Private/StreamThreadRestoreInMemoryTests.cs
@@ -45,7 +45,7 @@ namespace Streamiz.Kafka.Net.Tests.Private
             mockKafkaSupplier = new MockKafkaSupplier(2, 0);
 
             var builder = new StreamBuilder();
-            builder.Table("topic", InMemory<string, string>.As("store").WithLoggingEnabled());
+            builder.Table("topic", InMemory.As<string, string>("store").WithLoggingEnabled());
 
             var topo = builder.Build();
             topo.Builder.RewriteTopology(config);

--- a/test/Streamiz.Kafka.Net.Tests/Private/StreamThreadRestoreRocksDbTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Private/StreamThreadRestoreRocksDbTests.cs
@@ -45,7 +45,7 @@ namespace Streamiz.Kafka.Net.Tests.Private
             mockKafkaSupplier = new MockKafkaSupplier(2, 0);
 
             var builder = new StreamBuilder();
-            builder.Table("topic", RocksDb<string, string>.As("store").WithLoggingEnabled());
+            builder.Table("topic", RocksDb.As<string, string>("store").WithLoggingEnabled());
 
             var topo = builder.Build();
             topo.Builder.RewriteTopology(config);

--- a/test/Streamiz.Kafka.Net.Tests/Private/StreamThreadTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Private/StreamThreadTests.cs
@@ -115,21 +115,21 @@ namespace Streamiz.Kafka.Net.Tests.Private
         public void GetConsumerClientIdTest()
         {
             var result = StreamThread.GetConsumerClientId("thread-client");
-            Assert.AreEqual($"thread-client-consumer", result);
+            Assert.AreEqual($"thread-client-streamiz-consumer", result);
         }
 
         [Test]
         public void GetRestoreConsumerClientIdTest()
         {
             var result = StreamThread.GetRestoreConsumerClientId("thread-client");
-            Assert.AreEqual($"thread-client-restore-consumer", result);
+            Assert.AreEqual($"thread-client-streamiz-restore-consumer", result);
         }
 
         [Test]
         public void GetSharedAdminClientIdTest()
         {
             var result = StreamThread.GetSharedAdminClientId("thread-client");
-            Assert.AreEqual($"thread-client-admin", result);
+            Assert.AreEqual($"thread-client-streamiz-admin", result);
         }
 
         [Test]
@@ -137,14 +137,14 @@ namespace Streamiz.Kafka.Net.Tests.Private
         {
             var taskId = new TaskId {Id = 0, Partition = 0};
             var result = StreamThread.GetTaskProducerClientId("thread-client", taskId);
-            Assert.AreEqual($"thread-client-0-0-producer", result);
+            Assert.AreEqual($"thread-client-0-0-streamiz-producer", result);
         }
 
         [Test]
         public void GetThreadProducerClientIdTest()
         {
             var result = StreamThread.GetThreadProducerClientId("thread-client");
-            Assert.AreEqual($"thread-client-producer", result);
+            Assert.AreEqual($"thread-client-streamiz-producer", result);
         }
 
         #endregion

--- a/test/Streamiz.Kafka.Net.Tests/Private/TaskManagerTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Private/TaskManagerTests.cs
@@ -355,8 +355,8 @@ namespace Streamiz.Kafka.Net.Tests.Private
             var builder = new StreamBuilder();
             builder.Table("topic",
                 persistenStateStore
-                    ? RocksDb<string, string>.As("store").WithLoggingEnabled(null)
-                    : InMemory<string, string>.As("store").WithLoggingEnabled(null));
+                    ? RocksDb.As<string, string>("store").WithLoggingEnabled(null)
+                    : InMemory.As<string, string>("store").WithLoggingEnabled(null));
 
             var serdes = new StringSerDes();
 

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KGlobalTableTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KGlobalTableTests.cs
@@ -14,7 +14,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            var table = builder.GlobalTable("topic", InMemory<string, string>.As("global-store"));
+            var table = builder.GlobalTable("topic", InMemory.As<string, string>("global-store"));
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-globaltable";
 
@@ -36,7 +36,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            var table = builder.GlobalTable("topic", RocksDb<string, string>.As("global-store"));
+            var table = builder.GlobalTable("topic", RocksDb.As<string, string>("global-store"));
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-globaltable";
             config.UseRandomRocksDbConfigForTest();

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KGroupedStreamAggTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KGroupedStreamAggTests.cs
@@ -145,7 +145,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                .Stream<string, string>("topic")
                .GroupBy((k, v) => k.ToUpper());
 
-            stream.Count(InMemory<string, long>.As("count-store"));
+            stream.Count(InMemory.As<string, long>("count-store"));
             stream.Aggregate(
                     () => new Dictionary<char, int>(),
                     (k, v, old) =>
@@ -160,7 +160,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                         }
                         return old;
                     },
-                    InMemory<string, Dictionary<char, int>>.As("agg-store").WithValueSerdes<DictionarySerDes>()
+                    InMemory.As<string, Dictionary<char, int>>("agg-store").WithValueSerdes<DictionarySerDes>()
                 );
 
             var topology = builder.Build();
@@ -296,7 +296,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                .Aggregate(
                     () => 0L,
                     (k, v, agg) => agg + 1,
-                    InMemory<string, long>.As("agg-store").WithValueSerdes<Int64SerDes>());
+                    InMemory.As<string, long>("agg-store").WithValueSerdes<Int64SerDes>());
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KGroupedStreamCountTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KGroupedStreamCountTests.cs
@@ -117,7 +117,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             builder
                 .Stream<string, string>("topic")
                 .GroupBy<char, CharSerDes>((k, v) => k.ToCharArray()[0])
-                .Count(InMemory<char, long>.As("count-store").WithKeySerdes(new CharSerDes()));
+                .Count(InMemory.As<char, long>("count-store").WithKeySerdes(new CharSerDes()));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -145,7 +145,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             builder
                 .Stream<string, string>("topic")
                 .GroupBy<char, CharSerDes>((k, v) => k.ToCharArray()[0])
-                .Count(InMemory<char, long>.As("count-store").WithKeySerdes(new CharSerDes()));
+                .Count(InMemory.As<char, long>("count-store").WithKeySerdes(new CharSerDes()));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -242,7 +242,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             builder
                 .Stream<string, string>("topic")
                 .GroupBy((k, v) => k.ToCharArray()[0])
-                .Count(InMemory<char, long>.As("count-store"));
+                .Count(InMemory.As<char, long>("count-store"));
 
             var topology = builder.Build();
             Assert.Throws<StreamsException>(() =>

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KGroupedStreamReduceTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KGroupedStreamReduceTests.cs
@@ -115,10 +115,10 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                .MapValues(v => v.Length)
                .GroupBy<string, StringSerDes, Int32SerDes>((k, v) => k.ToUpper());
 
-            stream.Count(InMemory<string, long>.As("count-store"));
+            stream.Count(InMemory.As<string, long>("count-store"));
             stream.Reduce(
                     (v1, v2) => Math.Max(v1, v2),
-                    InMemory<string, int>.As("reduce-store").WithValueSerdes<Int32SerDes>());
+                    InMemory.As<string, int>("reduce-store").WithValueSerdes<Int32SerDes>());
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -158,7 +158,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                .GroupBy((k, v) => k.ToUpper())
                .Reduce(
                     (v1, v2) => v2.Length > v1.Length ? v2 : v1,
-                    InMemory<string, string>.As("reduce-store"));
+                    InMemory.As<string, string>("reduce-store"));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -187,7 +187,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             builder
                .Stream<string, string>("topic")
                .GroupBy((k, v) => k.ToUpper())
-               .Reduce(new MyReducer(), InMemory<string, string>.As("reduce-store"));
+               .Reduce(new MyReducer(), InMemory.As<string, string>("reduce-store"));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -218,7 +218,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                .GroupBy((k, v) => k.ToUpper())
                .Reduce(
                     new MyReducer(),
-                    InMemory<string, string>.As("reduce-store"),
+                    InMemory.As<string, string>("reduce-store"),
                     "reduce-processor");
 
             var topology = builder.Build();
@@ -252,7 +252,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                .GroupBy((k, v) => k?.ToUpper())
                .Reduce(
                     new MyReducer(),
-                    InMemory<string, string>.As("reduce-store"),
+                    InMemory.As<string, string>("reduce-store"),
                     "reduce-processor");
 
             var topology = builder.Build();

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KGroupedTableAggTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KGroupedTableAggTests.cs
@@ -153,7 +153,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .Table<string, string>("topic")
                 .GroupBy((k, v) => KeyValuePair.Create(k.ToUpper(), v));
 
-            table.Count(InMemory<string, long>.As("count-store"));
+            table.Count(InMemory.As<string, long>("count-store"));
             table.Aggregate(
                     () => new Dictionary<char, int>(),
                     (k, v, old) =>
@@ -169,7 +169,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                         return old;
                     },
                     (k, v, old) => old,
-                    InMemory<string, Dictionary<char, int>>.As("agg-store").WithValueSerdes<DictionarySerDes>()
+                    InMemory.As<string, Dictionary<char, int>>("agg-store").WithValueSerdes<DictionarySerDes>()
                 );
 
             var topology = builder.Build();
@@ -308,7 +308,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                     () => 0L,
                     (k, v, agg) => agg + 1,
                     (k, v, agg) => agg,
-                    InMemory<string, long>.As("agg-store").WithValueSerdes<Int64SerDes>());
+                    InMemory.As<string, long>("agg-store").WithValueSerdes<Int64SerDes>());
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KGroupedTableCountTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KGroupedTableCountTests.cs
@@ -120,7 +120,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             builder
                 .Table<string, string>("topic")
                 .GroupBy<char, string, CharSerDes, StringSerDes>((k, v) => KeyValuePair.Create(k.ToCharArray()[0], v))
-                .Count(InMemory<char, long>.As("count-store").WithKeySerdes(new CharSerDes()));
+                .Count(InMemory.As<char, long>("count-store").WithKeySerdes(new CharSerDes()));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -148,7 +148,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             builder
                 .Table<string, string>("topic")
                 .GroupBy<char, string, CharSerDes, StringSerDes>((k, v) => KeyValuePair.Create(k.ToCharArray()[0], v))
-                .Count(InMemory<char, long>.As("count-store").WithKeySerdes(new CharSerDes()));
+                .Count(InMemory.As<char, long>("count-store").WithKeySerdes(new CharSerDes()));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -176,7 +176,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             builder
                 .Table<string, string>("topic")
                 .GroupBy<char, string, CharSerDes, StringSerDes>((k, v) => KeyValuePair.Create(k.ToCharArray()[0], v))
-                .Count(InMemory<char, long>.As("count-store").WithKeySerdes(new CharSerDes()));
+                .Count(InMemory.As<char, long>("count-store").WithKeySerdes(new CharSerDes()));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -273,7 +273,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             builder
                 .Table<string, string>("topic")
                 .GroupBy((k, v) => KeyValuePair.Create(k.ToCharArray()[0], v))
-                .Count(InMemory<char, long>.As("count-store"));
+                .Count(InMemory.As<char, long>("count-store"));
 
             var topology = builder.Build();
             Assert.Throws<StreamsException>(() =>

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KGroupedTableReduceTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KGroupedTableReduceTests.cs
@@ -122,11 +122,11 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .MapValues(v => v.Length)
                 .GroupBy<string, int, StringSerDes, Int32SerDes>((k, v) => KeyValuePair.Create(k.ToUpper(), v));
 
-            table.Count(InMemory<string, long>.As("count-store"));
+            table.Count(InMemory.As<string, long>("count-store"));
             table.Reduce(
                     (v1, v2) => Math.Max(v1, v2),
                     (v1, v2) => Math.Max(v1, v2),
-                    InMemory<string, int>.As("reduce-store").WithValueSerdes<Int32SerDes>());
+                    InMemory.As<string, int>("reduce-store").WithValueSerdes<Int32SerDes>());
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -167,7 +167,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                    .Reduce(
                         (v1, v2) => v2.Length > v1.Length ? v2 : v1,
                         (v1, v2) => v2,
-                        InMemory<string, string>.As("reduce-store"));
+                        InMemory.As<string, string>("reduce-store"));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -196,7 +196,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             builder
                 .Table<string, string>("topic")
                 .GroupBy((k, v) => KeyValuePair.Create(k.ToUpper(), v))
-               .Reduce(new MyAddReducer(), new MySubReducer(), InMemory<string, string>.As("reduce-store"));
+               .Reduce(new MyAddReducer(), new MySubReducer(), InMemory.As<string, string>("reduce-store"));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -227,7 +227,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .GroupBy((k, v) => KeyValuePair.Create(k.ToUpper(), v))
                .Reduce(
                     new MyAddReducer(), new MySubReducer(),
-                    InMemory<string, string>.As("reduce-store"),
+                    InMemory.As<string, string>("reduce-store"),
                     "reduce-processor");
 
             var topology = builder.Build();
@@ -261,7 +261,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .GroupBy((k, v) => KeyValuePair.Create(k?.ToUpper(), v))
                .Reduce(
                     new MyAddReducer(), new MySubReducer(),
-                    InMemory<string, string>.As("reduce-store"),
+                    InMemory.As<string, string>("reduce-store"),
                     "reduce-processor");
 
             var topology = builder.Build();

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KStreamGlobalTableJoinTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KStreamGlobalTableJoinTests.cs
@@ -30,7 +30,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var global = builder.GlobalTable("global", InMemory<string, string>.As("global-store"));
+            var global = builder.GlobalTable("global", InMemory.As<string,string>("global-store"));
 
             builder
                 .Stream<string, string>("stream")
@@ -63,7 +63,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var global = builder.GlobalTable("global", InMemory<string, string>.As("global-store"));
+            var global = builder.GlobalTable("global", InMemory.As<string,string>("global-store"));
 
             builder
                 .Stream<string, string>("stream")
@@ -97,7 +97,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var global = builder.GlobalTable("global", InMemory<string, string>.As("global-store"));
+            var global = builder.GlobalTable("global", InMemory.As<string,string>("global-store"));
 
             builder
                 .Stream<string, string>("stream")

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KStreamGlobalTableLeftJoinTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KStreamGlobalTableLeftJoinTests.cs
@@ -30,7 +30,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var global = builder.GlobalTable("global", InMemory<string, string>.As("global-store"));
+            var global = builder.GlobalTable("global", InMemory.As<string,string>("global-store"));
 
             builder
                 .Stream<string, string>("stream")
@@ -63,7 +63,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var global = builder.GlobalTable("global", InMemory<string, string>.As("global-store"));
+            var global = builder.GlobalTable("global", InMemory.As<string,string>("global-store"));
 
             builder
                 .Stream<string, string>("stream")
@@ -97,7 +97,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var global = builder.GlobalTable("global", InMemory<string, string>.As("global-store"));
+            var global = builder.GlobalTable("global", InMemory.As<string,string>("global-store"));
 
             builder
                 .Stream<string, string>("stream")

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KStreamTableJoinTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KStreamTableJoinTests.cs
@@ -25,7 +25,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             StreamBuilder builder = new StreamBuilder();
 
             var table = builder
-                            .Table("test", InMemory<string, string>.As("store"));
+                            .Table("test", InMemory.As<string, string>("store"));
 
             builder
                 .Stream<string, string>("stream")
@@ -59,7 +59,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             StreamBuilder builder = new StreamBuilder();
 
             var table = builder
-                            .Table("test", InMemory<string, string>.As("store"));
+                            .Table("test", InMemory.As<string, string>("store"));
 
             builder
                 .Stream<string, string>("stream")
@@ -94,7 +94,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             StreamBuilder builder = new StreamBuilder();
 
             var table = builder
-                            .Table("test", InMemory<string, string>.As("store"));
+                            .Table("test", InMemory.As<string, string>("store"));
 
             builder
                 .Stream<string, string>("stream")

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KStreamTableLeftJoinTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KStreamTableLeftJoinTests.cs
@@ -27,7 +27,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             StreamBuilder builder = new StreamBuilder();
 
             var table = builder
-                            .Table("test", InMemory<string, string>.As("store"));
+                            .Table("test", InMemory.As<string, string>("store"));
 
             builder
                 .Stream<string, string>("stream")
@@ -65,7 +65,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             StreamBuilder builder = new StreamBuilder();
 
             var table = builder
-                            .Table("test", InMemory<string, string>.As("store"));
+                            .Table("test", InMemory.As<string, string>("store"));
 
             builder
                 .Stream<string, string>("stream")
@@ -103,7 +103,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             StreamBuilder builder = new StreamBuilder();
 
             var table = builder
-                            .Table("test", InMemory<string, string>.As("store"));
+                            .Table("test", InMemory.As<string, string>("store"));
 
             builder
                 .Stream<string, string>("stream")
@@ -141,7 +141,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             StreamBuilder builder = new StreamBuilder();
 
             var table = builder
-                            .Table("test", InMemory<string, string>.As("store"));
+                            .Table("test", InMemory.As<string,string>("store"));
 
             builder
                 .Stream<string, string>("stream")

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KStreamToTableTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KStreamToTableTests.cs
@@ -62,7 +62,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             var table = builder
                 .Stream<string, string>("test")
                 .Filter((k, v) => v.Length % 2 == 0)
-                .ToTable(InMemory<string, string>.As("table-store"));
+                .ToTable(InMemory.As<string, string>("table-store"));
 
             Topology t = builder.Build();
 

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KTableFilterNotTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KTableFilterNotTests.cs
@@ -29,7 +29,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             data.Add(KeyValuePair.Create("key3", "paper"));
 
             builder.Table<string, string>("table-topic")
-                .FilterNot((k, v) => v.Contains("test", StringComparison.InvariantCultureIgnoreCase), InMemory<string, string>.As("test-store"));
+                .FilterNot((k, v) => v.Contains("test", StringComparison.InvariantCultureIgnoreCase), InMemory.As<string, string>("test-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "table-test-filter";
@@ -61,7 +61,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             data.Add(KeyValuePair.Create("key3", "paper"));
 
             builder.Table<string, string>("table-topic")
-                .FilterNot((k, v) => v.Contains("test", StringComparison.InvariantCultureIgnoreCase), InMemory<string, string>.As("test-store"));
+                .FilterNot((k, v) => v.Contains("test", StringComparison.InvariantCultureIgnoreCase), InMemory.As<string, string>("test-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "table-test-filter";
@@ -94,7 +94,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             data.Add(KeyValuePair.Create("key3", "testkfkjdf"));
 
             builder.Table<string, string>("table-topic")
-                .FilterNot((k, v) => v.Contains("test", StringComparison.InvariantCultureIgnoreCase), InMemory<string, string>.As("test-store"));
+                .FilterNot((k, v) => v.Contains("test", StringComparison.InvariantCultureIgnoreCase), InMemory.As<string, string>("test-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "table-test-filter";

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KTableFilterTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KTableFilterTests.cs
@@ -29,7 +29,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             data.Add(KeyValuePair.Create("key3", "paper"));
 
             builder.Table<string, string>("table-topic")
-                .Filter((k, v) => v.Contains("test", StringComparison.InvariantCultureIgnoreCase), InMemory<string, string>.As("test-store"));
+                .Filter((k, v) => v.Contains("test", StringComparison.InvariantCultureIgnoreCase), InMemory.As<string, string>("test-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "table-test-filter";
@@ -61,7 +61,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             data.Add(KeyValuePair.Create("key3", "paper"));
 
             builder.Table<string, string>("table-topic")
-                .Filter((k, v) => v.Contains("test", StringComparison.InvariantCultureIgnoreCase), InMemory<string, string>.As("test-store"));
+                .Filter((k, v) => v.Contains("test", StringComparison.InvariantCultureIgnoreCase), InMemory.As<string, string>("test-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "table-test-filter";
@@ -92,7 +92,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             data.Add(KeyValuePair.Create("key3", "paper"));
 
             builder.Table<string, string>("table-topic")
-                .Filter((k, v) => v.Contains("test", StringComparison.InvariantCultureIgnoreCase), InMemory<string, string>.As("test-store"));
+                .Filter((k, v) => v.Contains("test", StringComparison.InvariantCultureIgnoreCase), InMemory.As<string, string>("test-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "table-test-filter";

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KTableKTableJoinTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KTableKTableJoinTests.cs
@@ -24,8 +24,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
             var tableJoin = table1.Join(table2, (v1, v2) => $"{v1}-{v2}");
 
@@ -58,8 +58,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
             var tableJoin = table1.Join(table2, new ValueJoiner());
 
@@ -91,10 +91,10 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
-            var tableJoin = table1.Join(table2, (v1, v2) => $"{v1}-{v2}", InMemory<string, string>.As("merge-store"));
+            var tableJoin = table1.Join(table2, (v1, v2) => $"{v1}-{v2}", InMemory.As<string,string>("merge-store"));
 
             tableJoin.ToStream().To("topic-output");
 
@@ -132,8 +132,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
             var tableJoin = table1.Join(table2, (v1, v2) => $"{v1}-{v2}");
             
@@ -166,8 +166,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
             var tableJoin = table1.Join(table2, (v1, v2) => $"{v1}-{v2}");
 
@@ -200,8 +200,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("users", InMemory<string, string>.As("store-users"));
-            var table2 = builder.Table("regions", InMemory<string, string>.As("store-regions"));
+            var table1 = builder.Table("users", InMemory.As<string,string>("store-users"));
+            var table2 = builder.Table("regions", InMemory.As<string,string>("store-regions"));
             var stream = builder.Stream<string, string>("orders");
 
             var tableJoin = table1.Join(table2, (v1, v2) => $"{v1}-{v2}");

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KTableKTableLeftJoinTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KTableKTableLeftJoinTests.cs
@@ -24,8 +24,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
             var tableJoin = table1.LeftJoin(table2, (v1, v2) => $"{v1}-{v2}");
 
@@ -60,8 +60,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
             var tableJoin = table1.LeftJoin(table2, new ValueJoiner());
 
@@ -91,10 +91,10 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
-            var tableJoin = table1.LeftJoin(table2, (v1, v2) => $"{v1}-{v2}", InMemory<string, string>.As("merge-store"));
+            var tableJoin = table1.LeftJoin(table2, (v1, v2) => $"{v1}-{v2}", InMemory.As<string,string>("merge-store"));
 
             tableJoin.ToStream().To("topic-output");
 
@@ -131,8 +131,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
             var tableJoin = table1.LeftJoin(table2, (v1, v2) => $"{v1}-{v2}");
 
@@ -166,8 +166,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
             var tableJoin = table1.LeftJoin(table2, (v1, v2) => $"{v1}-{v2}");
 
@@ -200,8 +200,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("users", InMemory<string, string>.As("store-users"));
-            var table2 = builder.Table("regions", InMemory<string, string>.As("store-regions"));
+            var table1 = builder.Table("users", InMemory.As<string,string>("store-users"));
+            var table2 = builder.Table("regions", InMemory.As<string,string>("store-regions"));
             var stream = builder.Stream<string, string>("orders");
 
             var tableJoin = table1.LeftJoin(table2, (v1, v2) => $"{v1}-{v2 ?? "?"}");

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KTableKTableOuterJoinTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KTableKTableOuterJoinTests.cs
@@ -24,8 +24,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
             var tableJoin = table1.OuterJoin(table2, (v1, v2) => $"{v1}-{v2}");
 
@@ -62,8 +62,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
             var tableJoin = table1.OuterJoin(table2, new ValueJoiner());
 
@@ -99,10 +99,10 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
-            var tableJoin = table1.OuterJoin(table2, (v1, v2) => $"{v1}-{v2}", InMemory<string, string>.As("merge-store"));
+            var tableJoin = table1.OuterJoin(table2, (v1, v2) => $"{v1}-{v2}", InMemory.As<string,string>("merge-store"));
 
             tableJoin.ToStream().To("topic-output");
 
@@ -142,8 +142,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
             var tableJoin = table1.OuterJoin(table2, (v1, v2) => $"{v1}-{v2}");
 
@@ -179,8 +179,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("table1", InMemory<string, string>.As("store1"));
-            var table2 = builder.Table("table2", InMemory<string, string>.As("store2"));
+            var table1 = builder.Table("table1", InMemory.As<string,string>("store1"));
+            var table2 = builder.Table("table2", InMemory.As<string,string>("store2"));
 
             var tableJoin = table1.LeftJoin(table2, (v1, v2) => $"{v1}-{v2}");
 
@@ -212,8 +212,8 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("users", InMemory<string, string>.As("store-users"));
-            var table2 = builder.Table("regions", InMemory<string, string>.As("store-regions"));
+            var table1 = builder.Table("users", InMemory.As<string,string>("store-users"));
+            var table2 = builder.Table("regions", InMemory.As<string,string>("store-regions"));
             var stream = builder.Stream<string, string>("orders");
 
             var tableJoin = table1.OuterJoin(table2, (v1, v2) => $"{v1 ?? "?"}-{v2 ?? "?"}");

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KTableMapValuesTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KTableMapValuesTests.cs
@@ -37,7 +37,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             data.Add(KeyValuePair.Create("key3", "paper"));
 
             builder.Table<string, string>("table-topic")
-                .MapValues((v) => v.Length, InMemory<string, int>.As("test-store").With<StringSerDes, Int32SerDes>());
+                .MapValues((v) => v.Length, InMemory.As<string,int>("test-store").With<StringSerDes, Int32SerDes>());
                 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "table-test-mapvalues";
@@ -72,7 +72,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             data.Add(KeyValuePair.Create("key3", "paper"));
 
             builder.Table<string, string>("table-topic")
-                .MapValues((v) => v.ToCharArray()[0].ToString(), InMemory<string, string>.As("test-store"));
+                .MapValues((v) => v.ToCharArray()[0].ToString(), InMemory.As<string,string>("test-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "table-test-mapvalues";

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KTableSourceTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KTableSourceTests.cs
@@ -95,7 +95,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             var builder = new StreamBuilder();
 
             builder.Table<string, string, StringSerDes, StringSerDes>
-                ("table-topic", InMemory.As<string,string>("table-topic-store"));
+                ("table-topic", InMemory.As<string,string, StringSerDes, StringSerDes>("table-topic-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KTableSourceTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KTableSourceTests.cs
@@ -36,7 +36,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            builder.Table("table-topic", InMemory<string, string>.As("table-topic-store"));
+            builder.Table("table-topic", InMemory.As<string,string>("table-topic-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";
@@ -66,7 +66,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             builder.Table("table-topic", 
                 new StringSerDes(), new StringSerDes(),
-                InMemory<string, string>.As("table-topic-store"));
+                InMemory.As<string,string>("table-topic-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";
@@ -95,7 +95,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             var builder = new StreamBuilder();
 
             builder.Table<string, string, StringSerDes, StringSerDes>
-                ("table-topic", InMemory<string, string>.As("table-topic-store"));
+                ("table-topic", InMemory.As<string,string>("table-topic-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";
@@ -124,7 +124,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             var builder = new StreamBuilder();
 
             builder.Table<string, string, StringSerDes, StringSerDes>
-                ("table-topic", InMemory<string, string>.As("table-topic-store"), "table");
+                ("table-topic", InMemory.As<string,string>("table-topic-store"), "table");
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";
@@ -153,7 +153,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             var builder = new StreamBuilder();
 
             builder.Table<string, string, StringSerDes, StringSerDes>
-                ("table-topic", InMemory<string, string>.As("table-topic-store"), new MyITimestampExtractor());
+                ("table-topic", InMemory.As<string,string>("table-topic-store"), new MyITimestampExtractor());
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";
@@ -182,7 +182,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
             var builder = new StreamBuilder();
 
             builder.Table<string, string, StringSerDes, StringSerDes>
-                ("table-topic", InMemory<string, string>.As("table-topic-store"), "table", new MyITimestampExtractor());
+                ("table-topic", InMemory.As<string,string>("table-topic-store"), "table", new MyITimestampExtractor());
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";
@@ -210,7 +210,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            builder.Table("table-topic", InMemory<string, string>.As("table-topic-store"));
+            builder.Table("table-topic", InMemory.As<string,string>("table-topic-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";
@@ -233,7 +233,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            builder.Table("table-topic", InMemory<string, string>.As("table-topic-store"));
+            builder.Table("table-topic", InMemory.As<string,string>("table-topic-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";
@@ -269,7 +269,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            builder.Table("table-topic", InMemory<string, string>.As("table-topic-store"));
+            builder.Table("table-topic", InMemory.As<string,string>("table-topic-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";
@@ -348,7 +348,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            builder.Table("table-topic", InMemory<string, string>.As("table-topic-store"));
+            builder.Table("table-topic", InMemory.As<string,string>("table-topic-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";
@@ -382,7 +382,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            builder.Table("table-topic", InMemory<string, string>.As("table-topic-store"));
+            builder.Table("table-topic", InMemory.As<string,string>("table-topic-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";
@@ -416,7 +416,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            builder.Table("table-topic", InMemory<string, string>.As("table-topic-store"));
+            builder.Table("table-topic", InMemory.As<string,string>("table-topic-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KTableToStreamTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KTableToStreamTests.cs
@@ -16,7 +16,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            builder.Table("table-topic", InMemory<string, string>.As("table-topic-store"))
+            builder.Table("table-topic", InMemory.As<string,string>("table-topic-store"))
                 .ToStream((k, v) => v.ToUpper())
                 .To("table-stream");
 
@@ -54,7 +54,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            builder.Table("table-topic", InMemory<string, string>.As("table-topic-store"))
+            builder.Table("table-topic", InMemory.As<string,string>("table-topic-store"))
                 .ToStream().To("table-stream");
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
@@ -93,7 +93,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            builder.Table("table-topic", InMemory<string, string>.As("table-topic-store"))
+            builder.Table("table-topic", InMemory.As<string,string>("table-topic-store"))
                 .ToStream().To("table-stream");
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
@@ -132,7 +132,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
         {
             var builder = new StreamBuilder();
 
-            builder.Table("table-topic", InMemory<string, string>.As("table-topic-store"))
+            builder.Table("table-topic", InMemory.As<string,string>("table-topic-store"))
                 .ToStream().To("table-stream");
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();

--- a/test/Streamiz.Kafka.Net.Tests/Processors/TableTableMergeJoinTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/TableTableMergeJoinTests.cs
@@ -18,9 +18,9 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("users", InMemory<string, string>.As("store-users"));
-            var table2 = builder.Table("regions", InMemory<string, string>.As("store-regions"));
-            var table3 = builder.Table("country", InMemory<string, string>.As("store-country"));
+            var table1 = builder.Table("users", InMemory.As<string,string>("store-users"));
+            var table2 = builder.Table("regions", InMemory.As<string,string>("store-regions"));
+            var table3 = builder.Table("country", InMemory.As<string,string>("store-country"));
             var stream = builder.Stream<string, string>("orders");
 
             var tableJoin = table1.LeftJoin(table2, (v1, v2) => $"{v1}-{v2 ?? "?"}");
@@ -65,12 +65,12 @@ namespace Streamiz.Kafka.Net.Tests.Processors
 
             StreamBuilder builder = new StreamBuilder();
 
-            var table1 = builder.Table("users", InMemory<string, string>.As("store-users"));
-            var table2 = builder.Table("regions", InMemory<string, string>.As("store-regions"));
-            var table3 = builder.Table("country", InMemory<string, string>.As("store-country"));
+            var table1 = builder.Table("users", InMemory.As<string,string>("store-users"));
+            var table2 = builder.Table("regions", InMemory.As<string,string>("store-regions"));
+            var table3 = builder.Table("country", InMemory.As<string,string>("store-country"));
             var stream = builder.Stream<string, string>("orders");
 
-            var tableJoin = table1.LeftJoin(table2, (v1, v2) => $"{v1}-{v2 ?? "?"}", InMemory<string, string>.As("merge1"));
+            var tableJoin = table1.LeftJoin(table2, (v1, v2) => $"{v1}-{v2 ?? "?"}", InMemory.As<string,string>("merge1"));
 
             var tableJoin2 = tableJoin.LeftJoin(table3, (v1, v2) => $"{v1}-{v2 ?? "?"}");
 

--- a/test/Streamiz.Kafka.Net.Tests/Processors/TimeWindowKStreamAggTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/TimeWindowKStreamAggTests.cs
@@ -163,7 +163,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .Aggregate(
                         () => 0,
                         (k, v, agg) => Math.Max(v.Length, agg),
-                        InMemoryWindows<string, int>.As("store").WithValueSerdes<Int32SerDes>())
+                        InMemoryWindows.As<string,int>("store").WithValueSerdes<Int32SerDes>())
                 .ToStream()
                 .To<StringTimeWindowedSerDes, Int32SerDes>("output");
 
@@ -217,7 +217,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .Aggregate(
                         () => 0,
                         (k, v, agg) => Math.Max(v.Length, agg),
-                        InMemoryWindows<string, int>.As("store").WithValueSerdes<Int32SerDes>())
+                        InMemoryWindows.As<string,int>("store").WithValueSerdes<Int32SerDes>())
                 .ToStream()
                 .To("output");
 
@@ -244,7 +244,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .Aggregate(
                         () => 0,
                         (k, v, agg) => Math.Max(v.Length, agg),
-                        InMemoryWindows<string, int>.As("store").WithValueSerdes<Int32SerDes>())
+                        InMemoryWindows.As<string,int>("store").WithValueSerdes<Int32SerDes>())
                 .ToStream()
                 .To<StringTimeWindowedSerDes, Int32SerDes>("output");
 
@@ -273,7 +273,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .Aggregate(
                         () => 0,
                         (k, v, agg) => Math.Max(v.Length, agg),
-                        InMemoryWindows<string, int>.As("store").WithValueSerdes<Int32SerDes>());
+                        InMemoryWindows.As<string,int>("store").WithValueSerdes<Int32SerDes>());
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -306,7 +306,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .Aggregate(
                         () => 0,
                         (k, v, agg) => Math.Max(v.Length, agg),
-                        InMemoryWindows<string, int>.As("store").WithValueSerdes<Int32SerDes>());
+                        InMemoryWindows.As<string,int>("store").WithValueSerdes<Int32SerDes>());
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))

--- a/test/Streamiz.Kafka.Net.Tests/Processors/TimeWindowKStreamCountTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/TimeWindowKStreamCountTests.cs
@@ -306,7 +306,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .Stream<string, string>("topic")
                 .GroupByKey()
                 .WindowedBy(TumblingWindowOptions.Of(TimeSpan.FromSeconds(10)))
-                .Count(InMemoryWindows<string, long>.As("count-store"));
+                .Count(InMemoryWindows.As<string,long>("count-store"));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -336,7 +336,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .Stream<string, string>("topic")
                 .GroupByKey()
                 .WindowedBy(TumblingWindowOptions.Of(TimeSpan.FromSeconds(5)))
-                .Count(InMemoryWindows<string, long>.As("count-store"));
+                .Count(InMemoryWindows.As<string,long>("count-store"));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))

--- a/test/Streamiz.Kafka.Net.Tests/Processors/TimeWindowKStreamReduceTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/TimeWindowKStreamReduceTests.cs
@@ -165,7 +165,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .WindowedBy(TumblingWindowOptions.Of(2000))
                 .Reduce(
                     (v1, v2) => v1.Length > v2.Length ? v1 : v2,
-                    InMemoryWindows<string, string>.As("store"))
+                    InMemoryWindows.As<string,string>("store"))
                 .ToStream()
                 .To<StringTimeWindowedSerDes, StringSerDes>("output");
 
@@ -216,7 +216,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .WindowedBy(TumblingWindowOptions.Of(2000))
                 .Reduce(
                     (v1, v2) => v1.Length > v2.Length ? v1 : v2,
-                    InMemoryWindows<string, string>.As("store"))
+                    InMemoryWindows.As<string,string>("store"))
                 .ToStream()
                 .To("output");
 
@@ -242,7 +242,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .WindowedBy(TumblingWindowOptions.Of(2000))
                 .Reduce(
                     (v1, v2) => v1.Length > v2.Length ? v1 : v2,
-                    InMemoryWindows<string, string>.As("store"))
+                    InMemoryWindows.As<string,string>("store"))
                 .ToStream()
                 .To<StringTimeWindowedSerDes, StringSerDes>("output");
 
@@ -269,7 +269,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .WindowedBy(TumblingWindowOptions.Of(2000))
                 .Reduce(
                     (v1, v2) => v1.Length > v2.Length ? v1 : v2,
-                    InMemoryWindows<string, string>.As("store"))
+                    InMemoryWindows.As<string,string>("store"))
                 .ToStream()
                 .To<StringTimeWindowedSerDes, StringSerDes>("output");
 
@@ -303,7 +303,7 @@ namespace Streamiz.Kafka.Net.Tests.Processors
                 .WindowedBy(TumblingWindowOptions.Of(2000))
                 .Reduce(
                     (v1, v2) => v1.Length > v2.Length ? v1 : v2,
-                    InMemoryWindows<string, string>.As("store"));
+                    InMemoryWindows.As<string,string>("store"));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))

--- a/test/Streamiz.Kafka.Net.Tests/Public/CustomWindowTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Public/CustomWindowTests.cs
@@ -180,6 +180,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
             var builder = new StreamBuilder();
             var grace = TimeSpan.FromMinutes(30);
 
+            // retention 2jours
             var stream = builder.Stream<string, int>(inputTopic);
             var sumStream = stream
                 .SelectKey((k, v) => 1)
@@ -187,8 +188,8 @@ namespace Streamiz.Kafka.Net.Tests.Public
                 .WindowedBy(new DailyTimeWindows(zone, windowStartHour, grace))
                 .Reduce(
                     (v1, v2) => v1 + v2,
-                    InMemoryWindows<int, int>
-                        .Create<Int32SerDes, Int32SerDes>()
+                    InMemoryWindows
+                        .As<int, int, Int32SerDes, Int32SerDes>(null)
                         .WithRetention(TimeSpan.FromDays(1) + grace))
                 .ToStream();
 

--- a/test/Streamiz.Kafka.Net.Tests/Public/KafkaStreamTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Public/KafkaStreamTests.cs
@@ -186,7 +186,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
             config.BootstrapServers = "127.0.0.1";
 
             var builder = new StreamBuilder();
-            builder.Table("topic", InMemory<string, string>.As("store"));
+            builder.Table("topic", InMemory.As<string,string>("store"));
 
             var t = builder.Build();
             var stream = new KafkaStream(t, config, new SyncKafkaSupplier());
@@ -232,7 +232,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
             config.BootstrapServers = "127.0.0.1";
 
             var builder = new StreamBuilder();
-            builder.Table("topic", InMemory<string, string>.As("store"));
+            builder.Table("topic", InMemory.As<string,string>("store"));
 
             var t = builder.Build();
             var stream = new KafkaStream(t, config, supplier);
@@ -280,7 +280,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
             var producer = supplier.GetProducer(config.ToProducerConfig());
 
             var builder = new StreamBuilder();
-            builder.Table("topic", InMemory<string, string>.As("store"));
+            builder.Table("topic", InMemory.As<string,string>("store"));
 
             var t = builder.Build();
             var stream = new KafkaStream(t, config, supplier);
@@ -341,7 +341,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
             var producer = supplier.GetProducer(config.ToProducerConfig());
 
             var builder = new StreamBuilder();
-            builder.Table("topic", InMemory<string, string>.As("store"));
+            builder.Table("topic", InMemory.As<string,string>("store"));
 
             var t = builder.Build();
             var stream = new KafkaStream(t, config, supplier);
@@ -395,7 +395,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
             config.BootstrapServers = "127.0.0.1";
 
             var builder = new StreamBuilder();
-            builder.Table("topic", InMemory<string, string>.As("store"));
+            builder.Table("topic", InMemory.As<string,string>("store"));
 
             var t = builder.Build();
             var stream = new KafkaStream(t, config, new SyncKafkaSupplier());
@@ -420,7 +420,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
                 .Stream<string, string>("test")
                 .GroupByKey()
                 .WindowedBy(TumblingWindowOptions.Of(TimeSpan.FromMinutes(1)))
-                .Count(InMemoryWindows<string, long>.As("store"));
+                .Count(InMemoryWindows.As<string,long>("store"));
 
             var t = builder.Build();
             var stream = new KafkaStream(t, config, new SyncKafkaSupplier());
@@ -473,7 +473,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
                 .Stream<string, string>("test")
                 .GroupByKey()
                 .WindowedBy(TumblingWindowOptions.Of(TimeSpan.FromMinutes(1)))
-                .Count(InMemoryWindows<string, long>.As("store"));
+                .Count(InMemoryWindows.As<string,long>("store"));
 
             var t = builder.Build();
             var stream = new KafkaStream(t, config, supplier);
@@ -540,7 +540,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
                 .Stream<string, string>("test")
                 .GroupByKey()
                 .WindowedBy(TumblingWindowOptions.Of(TimeSpan.FromMinutes(1)))
-                .Count(InMemoryWindows<string, long>.As("store"));
+                .Count(InMemoryWindows.As<string,long>("store"));
 
             var t = builder.Build();
             var stream = new KafkaStream(t, config, new SyncKafkaSupplier());
@@ -586,7 +586,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
             builder
                 .Stream<string, string>("test")
                 .GroupByKey()
-                .Count(InMemory<string, long>.As("store"));
+                .Count(InMemory.As<string,long>("store"));
 
             var t = builder.Build();
             var stream = new KafkaStream(t, config, new SyncKafkaSupplier());
@@ -630,7 +630,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
             config.PollMs = 1;
 
             var builder = new StreamBuilder();
-            builder.GlobalTable<string, string>("test", InMemory<string, string>.As("store"));
+            builder.GlobalTable<string, string>("test", InMemory.As<string,string>("store"));
 
             var supplier = new SyncKafkaSupplier();
             var producer = supplier.GetProducer(new ProducerConfig());

--- a/test/Streamiz.Kafka.Net.Tests/Public/StreamJoinPropsTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Public/StreamJoinPropsTests.cs
@@ -11,9 +11,9 @@ namespace Streamiz.Kafka.Net.Tests.Public
     {
         public long? WindowSize { get; set; }
 
-        public long Retention => 100;
+        public long Retention { get; set; } = 100;
 
-        public string Name => "TEST";
+        public string Name { get; set; } = "TEST";
         
         public string MetricsScope => "test-window";
 

--- a/test/Streamiz.Kafka.Net.Tests/Public/StreamTableJoinTimestampSynchronizationIntegrationTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Public/StreamTableJoinTimestampSynchronizationIntegrationTests.cs
@@ -59,7 +59,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
             // a timestamp extractor on the stream and / or table
             // when doing a KStreams/KTable join the framework will look up for the value of a given key
             // in the KTable at a timestamp <= to the timestamp of the event on the stream side
-            var userRegionsTable = builder.Table<string, string>(userRegionsTopic, stringSerdes, stringSerdes, InMemory<string, string>.As("table-store"), "table", timestampExtractor);
+            var userRegionsTable = builder.Table<string, string>(userRegionsTopic, stringSerdes, stringSerdes, InMemory.As<string,string>("table-store"), "table", timestampExtractor);
             var userClicksStream = builder.Stream<string, string>(userClicksTopic, stringSerdes, stringSerdes, timestampExtractor);
 
             userClicksStream
@@ -75,7 +75,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
 
             var builder = new StreamBuilder();
 
-            var userRegionsTable = builder.Table<string, string>(userRegionsTopic, stringSerdes, stringSerdes, InMemory<string, string>.As("table-store"), "table", timestampExtractor);
+            var userRegionsTable = builder.Table<string, string>(userRegionsTopic, stringSerdes, stringSerdes, InMemory.As<string,string>("table-store"), "table", timestampExtractor);
             var userClicksStream = builder.Stream<string, string>(userClicksTopic, stringSerdes, stringSerdes, timestampExtractor);
 
             userClicksStream
@@ -92,7 +92,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
 
             var builder = new StreamBuilder();
 
-            var userRegionsTable = builder.Table<string, string>(userRegionsTopic, stringSerdes, stringSerdes, InMemory<string, string>.As("table-store"), "table", timestampExtractor);
+            var userRegionsTable = builder.Table<string, string>(userRegionsTopic, stringSerdes, stringSerdes, InMemory.As<string,string>("table-store"), "table", timestampExtractor);
             var userClicksStream = builder.Stream<string, string>(userClicksTopic, stringSerdes, stringSerdes, timestampExtractor);
 
             // TODO : update when through processor is DONE
@@ -110,7 +110,7 @@ namespace Streamiz.Kafka.Net.Tests.Public
 
             var builder = new StreamBuilder();
 
-            var userRegionsTable = builder.Table<string, string>(userRegionsTopic, stringSerdes, stringSerdes, InMemory<string, string>.As("table-store"), "table", timestampExtractor);
+            var userRegionsTable = builder.Table<string, string>(userRegionsTopic, stringSerdes, stringSerdes, InMemory.As<string,string>("table-store"), "table", timestampExtractor);
             var userClicksStream = builder.Stream<string, string>(userClicksTopic, stringSerdes, stringSerdes, timestampExtractor);
 
             userClicksStream

--- a/test/Streamiz.Kafka.Net.Tests/Stores/RocksDbKeyValueBytesStoreSupplierTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Stores/RocksDbKeyValueBytesStoreSupplierTests.cs
@@ -16,7 +16,7 @@ namespace Streamiz.Kafka.Net.Tests.Stores
         {
             var builder = new StreamBuilder();
 
-            builder.Table("table-topic", RocksDb<string, string>.As<StringSerDes, StringSerDes>("table-topic-store"));
+            builder.Table("table-topic", RocksDb.As<string,string, StringSerDes, StringSerDes>("table-topic-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-map";
@@ -47,7 +47,7 @@ namespace Streamiz.Kafka.Net.Tests.Stores
             var builder = new StreamBuilder();
 
             // Same like that : 
-            // builder.Table("table-topic", RocksDb<string, string>.As("table-topic-store"));
+            // builder.Table("table-topic", RocksDb.As<string,string>("table-topic-store"));
             builder.Table("table-topic",
                 Materialized<string, string, IKeyValueStore<Bytes, byte[]>>.Create(
                     Streamiz.Kafka.Net.State.Stores.PersistentKeyValueStore("table-topic-store")));

--- a/test/Streamiz.Kafka.Net.Tests/Stores/RocksDbWindowBytesStoreSupplierTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Stores/RocksDbWindowBytesStoreSupplierTests.cs
@@ -43,8 +43,49 @@ namespace Streamiz.Kafka.Net.Tests.Stores
                 Assert.AreEqual(1L, k1[0].Value);
                 Assert.AreEqual(1L, k1[1].Value);
             }
+
             config.RemoveRocksDbFolderForTest();
         }
+
+        [Test]
+        public void WindowingBis()
+        {
+            var builder = new StreamBuilder();
+
+            builder.Stream<string, string>("topic")
+                .GroupByKey()
+                .WindowedBy(TumblingWindowOptions.Of(1000))
+                .Count(
+                    RocksDbWindows
+                        .As<string, long>("rocksdb-w-store")
+                        .WithKeySerdes(new StringSerDes())
+                        .WithValueSerdes(new Int64SerDes()));
+
+            var config = new StreamConfig<StringSerDes, StringSerDes>();
+            config.ApplicationId = "test-rocksdb-window-bis-store";
+            config.UseRandomRocksDbConfigForTest();
+
+            Topology t = builder.Build();
+
+            using (var driver = new TopologyTestDriver(t, config))
+            {
+                DateTime dt = DateTime.Now;
+                var inputTopic = driver.CreateInputTopic<string, string>("topic");
+                inputTopic.PipeInput("key1", "1", dt);
+                inputTopic.PipeInput("key2", "2", dt);
+
+                var store = driver.GetWindowStore<string, long>("rocksdb-w-store");
+                Assert.IsNotNull(store);
+                var k1 = store.FetchAll(dt.AddMinutes(-10), dt.AddMinutes(10)).ToList();
+
+                Assert.AreEqual(2, k1.Count);
+                Assert.AreEqual(1L, k1[0].Value);
+                Assert.AreEqual(1L, k1[1].Value);
+            }
+
+            config.RemoveRocksDbFolderForTest();
+        }
+
 
         [Test]
         public void StoresPersistentKeyValueStoreTest()
@@ -55,16 +96,16 @@ namespace Streamiz.Kafka.Net.Tests.Stores
                 .GroupByKey()
                 .WindowedBy(TumblingWindowOptions.Of(1000))
                 .Count(
-                      Materialized<string, long, IWindowStore<Bytes, byte[]>>.Create(
-                    Streamiz.Kafka.Net.State.Stores.PersistentWindowStore(
-                        "rocksdb-w-store",
-                        TimeSpan.FromDays(1),
-                        TimeSpan.FromSeconds(1))));
+                    Materialized<string, long, IWindowStore<Bytes, byte[]>>.Create(
+                        Streamiz.Kafka.Net.State.Stores.PersistentWindowStore(
+                            "rocksdb-w-store",
+                            TimeSpan.FromDays(1),
+                            TimeSpan.FromSeconds(1))));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-rocksdb-window-store";
             config.UseRandomRocksDbConfigForTest();
-            
+
             Topology t = builder.Build();
 
             using (var driver = new TopologyTestDriver(t, config))
@@ -81,6 +122,7 @@ namespace Streamiz.Kafka.Net.Tests.Stores
 
                 Assert.AreEqual(3, k1.Count);
             }
+
             config.RemoveRocksDbFolderForTest();
         }
     }

--- a/test/Streamiz.Kafka.Net.Tests/Stores/RocksDbWindowBytesStoreSupplierTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Stores/RocksDbWindowBytesStoreSupplierTests.cs
@@ -20,7 +20,7 @@ namespace Streamiz.Kafka.Net.Tests.Stores
             builder.Stream<string, string>("topic")
                 .GroupByKey()
                 .WindowedBy(TumblingWindowOptions.Of(1000))
-                .Count(RocksDbWindows<string, long>.As<StringSerDes, Int64SerDes>("rocksdb-w-store"));
+                .Count(RocksDbWindows.As<string, long, StringSerDes, Int64SerDes>("rocksdb-w-store"));
 
             var config = new StreamConfig<StringSerDes, StringSerDes>();
             config.ApplicationId = "test-rocksdb-window-store";

--- a/test/Streamiz.Kafka.Net.Tests/TestDriver/ClusterInMemoryTopologyDriverTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/TestDriver/ClusterInMemoryTopologyDriverTests.cs
@@ -87,7 +87,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
             topicConfiguration.ApplicationId = $"test-driver-{config.ApplicationId}";
 
             var builder = new StreamBuilder();
-            builder.Table<string, string>("test", InMemory<string, string>.As("store"));
+            builder.Table<string, string>("test", InMemory.As<string, string>("store"));
             var driver = new ClusterInMemoryTopologyDriver("client", builder.Build().Builder, config, topicConfiguration, TimeSpan.FromSeconds(1), source.Token);
             driver.StartDriver();
             var input = driver.CreateInputTopic("test", new StringSerDes(), new StringSerDes());
@@ -115,7 +115,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
             topicConfiguration.ApplicationId = $"test-driver-{config.ApplicationId}";
 
             var builder = new StreamBuilder();
-            builder.Table("test", InMemory<string, string>.As("store"));
+            builder.Table("test", InMemory.As<string, string>("store"));
             var driver = new ClusterInMemoryTopologyDriver("client", builder.Build().Builder, config, topicConfiguration, TimeSpan.FromSeconds(1), source.Token);
             driver.StartDriver();
             var input = driver.CreateInputTopic("test", new StringSerDes(), new StringSerDes());
@@ -149,7 +149,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
             topicConfiguration.ApplicationId = $"test-driver-{config.ApplicationId}";
 
             var builder = new StreamBuilder();
-            builder.Table<string, string>("test", InMemory<string, string>.As("store"));
+            builder.Table<string, string>("test", InMemory.As<string, string>("store"));
             var driver = new ClusterInMemoryTopologyDriver("client", builder.Build().Builder, config, topicConfiguration, TimeSpan.FromSeconds(1), source.Token);
             driver.StartDriver();
             var input = driver.CreateInputTopic("test", new StringSerDes(), new StringSerDes());
@@ -183,7 +183,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
             topicConfiguration.ApplicationId = $"test-driver-{config.ApplicationId}";
 
             var builder = new StreamBuilder();
-            builder.Table("test", InMemory<string, string>.As("store"));
+            builder.Table("test", InMemory.As<string, string>("store"));
             var driver = new ClusterInMemoryTopologyDriver("client", builder.Build().Builder, config, topicConfiguration, TimeSpan.FromSeconds(1), source.Token);
             driver.StartDriver();
             var input = driver.CreateInputTopic("test", new StringSerDes(), new StringSerDes());
@@ -214,7 +214,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
             topicConfiguration.ApplicationId = $"test-driver-{config.ApplicationId}";
 
             var builder = new StreamBuilder();
-            builder.Table("test", InMemory<string, string>.As("store"));
+            builder.Table("test", InMemory.As<string, string>("store"));
             var driver = new ClusterInMemoryTopologyDriver("client", builder.Build().Builder, config, topicConfiguration, TimeSpan.FromSeconds(1), source.Token);
             driver.StartDriver();
             var input = driver.CreateInputTopic("test", new StringSerDes(), new StringSerDes());
@@ -258,7 +258,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
 
             var builder = new StreamBuilder();
             
-            var globalktable = builder.GlobalTable("test", InMemory<string, string>.As("global-store"));
+            var globalktable = builder.GlobalTable("test", InMemory.As<string, string>("global-store"));
             builder.Stream<string ,string>("source")
                 .Join(globalktable, 
                     (k,v) => k,

--- a/test/Streamiz.Kafka.Net.Tests/TestDriver/TaskSynchronousTopologyDriverTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/TestDriver/TaskSynchronousTopologyDriverTests.cs
@@ -58,7 +58,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
             config.ApplicationId = "test-config";
 
             var builder = new StreamBuilder();
-            builder.Table<string, string>("test", InMemory<string, string>.As("store"));
+            builder.Table<string, string>("test", InMemory.As<string, string>("store"));
 
             var driver = new TaskSynchronousTopologyDriver("client", builder.Build().Builder, config, config, default);
             driver.StartDriver();
@@ -80,7 +80,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
             config.ApplicationId = "test-config";
 
             var builder = new StreamBuilder();
-            builder.Table<string, string>("test", InMemory<string, string>.As("store"));
+            builder.Table<string, string>("test", InMemory.As<string, string>("store"));
 
             var driver = new TaskSynchronousTopologyDriver("client", builder.Build().Builder, config, config, default);
             driver.StartDriver();
@@ -107,7 +107,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
             config.ApplicationId = "test-config";
 
             var builder = new StreamBuilder();
-            builder.Table<string, string>("test", InMemory<string, string>.As("store"));
+            builder.Table<string, string>("test", InMemory.As<string, string>("store"));
 
             var driver = new TaskSynchronousTopologyDriver("client", builder.Build().Builder, config, config, default);
             driver.StartDriver();
@@ -137,7 +137,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
             builder.Stream<string, string>("test")
                             .GroupByKey()
                             .WindowedBy(TumblingWindowOptions.Of(2000))
-                            .Count(InMemoryWindows<string, long>.As("store"));
+                            .Count(InMemoryWindows.As<string, long>("store"));
 
             var driver = new TaskSynchronousTopologyDriver("client", builder.Build().Builder, config, config, default);
             driver.StartDriver();
@@ -165,7 +165,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
             builder.Stream<string, string>("test")
                             .GroupByKey()
                             .WindowedBy(TumblingWindowOptions.Of(2000))
-                            .Count(InMemoryWindows<string, long>.As("store"));
+                            .Count(InMemoryWindows.As<string, long>("store"));
 
             var driver = new TaskSynchronousTopologyDriver("client", builder.Build().Builder, config, config, default);
             driver.StartDriver();

--- a/test/Streamiz.Kafka.Net.Tests/TestDriver/TopologyTestDriverTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/TestDriver/TopologyTestDriverTests.cs
@@ -26,7 +26,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
                 .Stream<string, string>("topic")
                 .GroupByKey()
                 .WindowedBy(TumblingWindowOptions.Of(TimeSpan.FromSeconds(5)))
-                .Count(InMemoryWindows<string, long>.As("count-store"));
+                .Count(InMemoryWindows.As<string, long>("count-store"));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -51,7 +51,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
                 .Stream<string, string>("topic")
                 .GroupByKey()
                 .WindowedBy(TumblingWindowOptions.Of(TimeSpan.FromSeconds(5)))
-                .Count(InMemoryWindows<string, long>.As("count-store"));
+                .Count(InMemoryWindows.As<string, long>("count-store"));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))
@@ -75,7 +75,7 @@ namespace Streamiz.Kafka.Net.Tests.TestDriver
             builder
                 .Stream<string, string>("topic")
                 .GroupByKey()
-                .Count(InMemory<string, long>.As("count-store"));
+                .Count(InMemory.As<string, long>("count-store"));
 
             var topology = builder.Build();
             using (var driver = new TopologyTestDriver(topology, config))


### PR DESCRIPTION
This PR solve the issue #173

Before :

``` csharp
    RocksDb<string, long>.As("count-store")
```

Now, `InMemory`, `InMemoryWindows`, `RocksDb`, `RocksDbWindows` are a helper classes and not `Materialized`child classes.

So, syntax will change but not in the public DSL API.

New implementation for instance : 

```csharp
   InMemory.As<string, long>("count-store");
   InMemoryWindows.As<string, long>("count-store", TimeSpan.FromMinutes(1));
   RocksDb.As<string, long>("count-store");
   RocksDbWindows.As<string, long>("count-store", TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(1));    
```



