### PR TITLE
193 persistentwindowstore lazy loading issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ has been licensed for use by Streamiz. Streamiz has no
 affiliation with and is not endorsed by The Apache Software Foundation.
 ```
 
-It's allowed to develop .NET applications that transform input Kafka topics into output Kafka topics. 
-It's supported .NET Standard 2.1. It's a rewriting inspired by [Kafka Streams](https://github.com/apache/kafka).
-
 # Try it with Gitpod
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/LGouellec/kafka-streams-dotnet)
@@ -56,11 +53,6 @@ Switch to `producer` terminal and send sentences or word. The sample case is "Co
 
 Switch to `consumer`terminal and check aggregation result
 
-
-# ROADMAP
-
-- 1.4.0 - Async processor, Processor API
-- 1.5.0 - Interactive Queries, Standby Replica
 
 # Documentation
 
@@ -89,7 +81,7 @@ static async System.Threading.Tasks.Task Main(string[] args)
     StreamBuilder builder = new StreamBuilder();
 
     var kstream = builder.Stream<string, string>("stream");
-    var ktable = builder.Table("table", InMemory<string, string>.As("table-store"));
+    var ktable = builder.Table("table", InMemory.As<string, string>("table-store"));
 
     kstream.Join(ktable, (v, v1) => $"{v}-{v1}")
            .To("join-topic");

--- a/core/Processors/Internal/ProcessorStateManager.cs
+++ b/core/Processors/Internal/ProcessorStateManager.cs
@@ -250,11 +250,11 @@ namespace Streamiz.Kafka.Net.Processors.Internal
                     loadedCheckpoints.Remove(kvStore.Value.ChangelogTopicPartition);
                     log.LogDebug($"Skipping re-initialization of offset from checkpoint for recycled store {kvStore.Value.Store.Name}");
                 }
-
-                if (loadedCheckpoints.Any())
-                {
-                    log.LogWarning($"Some loaded checkpoint offsets cannot find their corresponding state stores: {string.Join(",", loadedCheckpoints.Select(c => $"[{c.Key.Topic}-{c.Key.Partition}]-{c.Value}"))}");
-                }
+            }
+            
+            if (loadedCheckpoints.Any())
+            {
+                log.LogWarning($"Some loaded checkpoint offsets cannot find their corresponding state stores: {string.Join(",", loadedCheckpoints.Select(c => $"[{c.Key.Topic}-{c.Key.Partition}]-{c.Value}"))}");
             }
         }
 

--- a/core/State/Internal/AbstractSegments.cs
+++ b/core/State/Internal/AbstractSegments.cs
@@ -88,11 +88,11 @@ namespace Streamiz.Kafka.Net.State.Internal
             {
                 var directory = Directory.CreateDirectory(Path.Combine(context.StateDir, name));
                 directory
-                    .GetFiles()
-                    .Select(s => SegmentIdFromSegmentName(s.Name))
-                    .OrderBy(l => l)
-                    .ToList()
-                    .ForEach(segId => GetOrCreateSegment(segId, context));
+                        .GetDirectories()
+                        .Select(s => SegmentIdFromSegmentName(s.Name))
+                        .OrderBy(l => l)
+                        .ToList()
+                        .ForEach(segId => GetOrCreateSegment(segId, context));
             }
             catch (Exception) {
                 throw new ProcessorStateException($"{Path.Combine(context.StateDir, name)}  doesn't exist and cannot be created for segments {name}");

--- a/samples/sample-stream/Program.cs
+++ b/samples/sample-stream/Program.cs
@@ -16,22 +16,22 @@ namespace sample_stream
     {
         public static async Task Main(string[] args)
         {
-            var topicSource = "words";
-            var config = new StreamConfig<StringSerDes, StringSerDes>();
-            config.ApplicationId = "test-app-reproducer";
-            config.BootstrapServers = "localhost:9092";
-            config.AutoOffsetReset = AutoOffsetReset.Earliest;
-            config.CommitIntervalMs = 5000;
-            
+            var config = new StreamConfig<StringSerDes, StringSerDes>
+            {
+                ApplicationId = "test-app-reproducer",
+                BootstrapServers = "localhost:9092",
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                CommitIntervalMs = 5000
+            };
+
             StreamBuilder builder = new StreamBuilder();
-            builder
-                .Stream<string, string>(topicSource)
-                .FlatMapValues((k, v) => v.Split((" ")).ToList())
-                .SelectKey((k, v) => v)
-                .GroupByKey()
-                .Count(RocksDb.As<string, long>("count-store")
-                    .WithKeySerdes(new StringSerDes())
-                    .WithValueSerdes(new Int64SerDes()));
+            var stream1 = builder.Stream<string, string>("topic1");
+            var stream2 = builder.Stream<string, string>("topic2");
+                
+            stream1.Join(stream2, 
+                (v1,v2) => $"{v1}-{v2}",
+                JoinWindowOptions.Of(TimeSpan.FromHours(1)))
+                .To("topic3");
             
             Topology t = builder.Build();
             KafkaStream stream = new KafkaStream(t, config);


### PR DESCRIPTION
The `RocksDbWindowStore` contains multiple segments. Each segment is the RocksDb store full fledged.

During the ` store.Init(context, ...) ` method, the window store has to open all existing segments and opening the rocksdb inside.

Each segment is a sub-directory and NOT a file like [here](https://github.com/LGouellec/kafka-streams-dotnet/commit/95494cfb332e3f95b89abb782664492a0aa1980e?diff=split#diff-41f0790ad1bb4d39a472750f2bff066f6d51dc2dceafce56a8e195ff83755aeaL91) .

The fix consist to replace `directory.GetFiles()` to ` directory.GetDirectories()`
