### PR TITLE
fix: ordering of error log parameters

### DIFF
--- a/core/Processors/GlobalStreamThread.cs
+++ b/core/Processors/GlobalStreamThread.cs
@@ -142,7 +142,7 @@ namespace Streamiz.Kafka.Net.Processors
                 }
                 catch (Exception e)
                 {
-                    log.LogError($"{logPrefix}exception caught during disposing of GlobalStreamThread.", e);
+                    log.LogError(e, $"{logPrefix}exception caught during disposing of GlobalStreamThread.");
                     // ignore exception
                     // https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1065
                 }

--- a/core/Processors/StreamTask.cs
+++ b/core/Processors/StreamTask.cs
@@ -164,7 +164,7 @@ namespace Streamiz.Kafka.Net.Processors
                     catch (KafkaException e)
                     {
                         // TODO : get info about offset committing
-                        log.LogError($"{logPrefix}Error during committing offset ......", e);
+                        log.LogError(e, $"{logPrefix}Error during committing offset ......");
                     }
                 }
                 commitNeeded = false;


### PR DESCRIPTION
This PR fixes a bug where the exception details were not being logged due to the exception object being passed in the wrong parameter.