### PR TITLE
feat(Record): add Record.WithHeaders

### DIFF
--- a/core/ProcessorContext.cs
+++ b/core/ProcessorContext.cs
@@ -101,10 +101,11 @@ namespace Streamiz.Kafka.Net
             RecordContext.ChangeTimestamp(ts);
         }
 
-        internal void SetHeaders(Headers headers)
-        {
-            RecordContext.SetHeaders(headers);
-        }
+        /// <summary>
+        /// Change current list of headers
+        /// </summary>
+        /// <param name="headers">new headers</param>
+        public void SetHeaders(Headers headers) => RecordContext.SetHeaders(headers);
 
         public virtual IStateStore GetStateStore(string storeName) => States.GetStore(storeName);
 

--- a/core/ProcessorContext.cs
+++ b/core/ProcessorContext.cs
@@ -101,6 +101,11 @@ namespace Streamiz.Kafka.Net
             RecordContext.ChangeTimestamp(ts);
         }
 
+        internal void SetHeaders(Headers headers)
+        {
+            RecordContext.SetHeaders(headers);
+        }
+
         public virtual IStateStore GetStateStore(string storeName) => States.GetStore(storeName);
 
         internal void Register(IStateStore store, StateRestoreCallback callback)

--- a/core/Processors/IRecordContext.cs
+++ b/core/Processors/IRecordContext.cs
@@ -33,5 +33,11 @@ namespace Streamiz.Kafka.Net.Processors
         /// </summary>
         /// <param name="ts">new timestamp</param>
         void ChangeTimestamp(long ts);
+
+        /// <summary>
+        /// Change current list of headers
+        /// </summary>
+        /// <param name="headers">new headers</param>
+        void SetHeaders(Headers headers);
     }
 }

--- a/core/Processors/Internal/RecordContext.cs
+++ b/core/Processors/Internal/RecordContext.cs
@@ -21,11 +21,16 @@ namespace Streamiz.Kafka.Net.Processors.Internal
 
         public int Partition { get; }
 
-        public Headers Headers { get; }
+        public Headers Headers { get; internal set; }
 
         public void ChangeTimestamp(long ts)
         {
             Timestamp = ts;
+        }
+
+        public void SetHeaders(Headers headers)
+        {
+            Headers = headers;
         }
     }
 }

--- a/core/Processors/Public/Record.cs
+++ b/core/Processors/Public/Record.cs
@@ -18,7 +18,7 @@ namespace Streamiz.Kafka.Net.Processors.Public
         /// <summary>
         /// Headers of the record (readonly)
         /// </summary>
-        public Headers Headers { get; internal set; }
+        public Headers Headers { get; }
         
         /// <summary>
         /// Timestamp of the record (readonly)

--- a/core/Processors/Public/Record.cs
+++ b/core/Processors/Public/Record.cs
@@ -18,7 +18,7 @@ namespace Streamiz.Kafka.Net.Processors.Public
         /// <summary>
         /// Headers of the record (readonly)
         /// </summary>
-        public Headers Headers { get; }
+        public Headers Headers { get; internal set; }
         
         /// <summary>
         /// Timestamp of the record (readonly)
@@ -71,5 +71,16 @@ namespace Streamiz.Kafka.Net.Processors.Public
         /// <returns>return a new value record</returns>
         public static Record<K, V> Create(V value)
             => new(value);
+
+        /// <summary>
+        /// Duplicate this record with a new set of headers
+        /// </summary>
+        /// <param name="headers">The headers you wish to assign to this record.</param>
+        /// <returns>a new record with the same key/value and updated headers</returns>
+        public Record<K, V> WithHeaders(Headers headers)
+        {
+            Headers = headers;
+            return this;
+        }
     }
 }

--- a/core/Processors/Public/Record.cs
+++ b/core/Processors/Public/Record.cs
@@ -72,15 +72,5 @@ namespace Streamiz.Kafka.Net.Processors.Public
         public static Record<K, V> Create(V value)
             => new(value);
 
-        /// <summary>
-        /// Duplicate this record with a new set of headers
-        /// </summary>
-        /// <param name="headers">The headers you wish to assign to this record.</param>
-        /// <returns>a new record with the same key/value and updated headers</returns>
-        public Record<K, V> WithHeaders(Headers headers)
-        {
-            Headers = headers;
-            return this;
-        }
     }
 }

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KStreamSetHeadersTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KStreamSetHeadersTests.cs
@@ -1,0 +1,186 @@
+﻿using Confluent.Kafka;
+using NUnit.Framework;
+using Streamiz.Kafka.Net.Mock;
+using Streamiz.Kafka.Net.Processors.Public;
+using Streamiz.Kafka.Net.SerDes;
+using Streamiz.Kafka.Net.Stream;
+using System;
+using System.Linq;
+using System.Text;
+
+namespace Streamiz.Kafka.Net.Tests.Processors
+{
+    public class KStreamSetHeadersTests
+    {
+        internal class TestHeadersTransformer : ITransformer<string, string, string, string>
+        {
+            private ProcessorContext _context;
+
+            public void Close()
+            { }
+
+            public void Init(ProcessorContext<string, string> context)
+            {
+                this._context = context;
+            }
+
+            public Record<string, string> Process(Record<string, string> record)
+            {
+                Headers headers = record.Headers ?? new Headers();
+                headers.Add("headers-test", Encoding.UTF8.GetBytes("headers-1234"));
+                this._context.SetHeaders(headers);
+
+                return record;
+            }
+        }
+
+        private string GetHeaderValue(IHeader header)
+        {
+            return Encoding.UTF8.GetString(header.GetValueBytes());
+        }
+
+        [Test]
+        public void ShouldHaveHeaders()
+        {
+            StreamConfig config = new StreamConfig<StringSerDes, StringSerDes>();
+            config.ApplicationId = "test-set-headers-test";
+
+            StreamBuilder builder = new();
+
+            builder.Stream<string, string>("test")
+                .Transform(TransformerBuilder.New<string, string, string, string>()
+                    .Transformer<TestHeadersTransformer>()
+                    .Build()
+                )
+                .To("test-output");
+
+            Topology t = builder.Build();
+            TopologyTestDriver driver = new(t, config);
+
+            var inputTopic = driver.CreateInputTopic<string, string>("test");
+            inputTopic.PipeInput("test-with-headers", "test-1234");
+
+            var outputTopic = driver.CreateOuputTopic<string, string>("test-output", TimeSpan.FromSeconds(10));
+
+            ConsumeResult<string, string> r = outputTopic.ReadKeyValue();
+            Assert.AreEqual("test-with-headers", r.Message.Key);
+            Assert.AreEqual("test-1234", r.Message.Value);
+
+            Headers rHeaders = r.Message.Headers;
+            Assert.IsNotNull(rHeaders);
+            Assert.IsTrue(rHeaders.Count > 0);
+            IHeader header = rHeaders.FirstOrDefault();
+            Assert.AreEqual("headers-test", header.Key);
+            Assert.AreEqual("headers-1234", GetHeaderValue(header));
+        }
+
+        [Test]
+        public void ShouldNotHaveHeaders()
+        {
+            StreamConfig config = new StreamConfig<StringSerDes, StringSerDes>();
+            config.ApplicationId = "test-no-headers-test";
+
+            StreamBuilder builder = new();
+
+            builder.Stream<string, string>("test")
+                .To("test-output");
+
+            Topology t = builder.Build();
+            TopologyTestDriver driver = new(t, config);
+
+            var inputTopic = driver.CreateInputTopic<string, string>("test");
+            inputTopic.PipeInput("test-no-headers", "test-5678");
+
+            var outputTopic = driver.CreateOuputTopic<string, string>("test-output", TimeSpan.FromSeconds(10));
+            ConsumeResult<string, string> r = outputTopic.ReadKeyValue();
+
+            Assert.AreEqual("test-no-headers", r.Message.Key);
+            Assert.AreEqual("test-5678", r.Message.Value);
+            Assert.IsTrue(r.Message.Headers.Count <= 0);
+        }
+
+        [Test]
+        public void ShouldAddToHeaders()
+        {
+            StreamConfig config = new StreamConfig<StringSerDes, StringSerDes>();
+            config.ApplicationId = "test-add-headers-test";
+
+            StreamBuilder builder = new();
+
+            builder.Stream<string, string>("test")
+                .Transform(TransformerBuilder.New<string, string, string, string>()
+                    .Transformer<TestHeadersTransformer>()
+                    .Build()
+                )
+                .To("test-output");
+
+            Topology t = builder.Build();
+            TopologyTestDriver driver = new(t, config);
+
+            var inputTopic = driver.CreateInputTopic<string, string>("test");
+            Headers headers = new()
+            {
+                { "first-header", Encoding.UTF8.GetBytes("first-test-header") }
+            };
+            inputTopic.PipeInput("test-add-headers", "test-9012", headers);
+
+            var outputTopic = driver.CreateOuputTopic<string, string>("test-output", TimeSpan.FromSeconds(10));
+            ConsumeResult<string, string> r = outputTopic.ReadKeyValue();
+
+            Assert.AreEqual("test-add-headers", r.Message.Key);
+            Assert.AreEqual("test-9012", r.Message.Value);
+            Assert.IsTrue(r.Message.Headers.Count == 2);
+
+            // Check headers
+            Headers expectedHeaders = new()
+            {
+                { "first-header", Encoding.UTF8.GetBytes("first-test-header") },
+                { "headers-test", Encoding.UTF8.GetBytes("headers-1234") }
+            };
+            for (int i = 0; i < r.Message.Headers.Count; i++)
+            {
+                IHeader header = r.Message.Headers[i];
+                IHeader expectedHeader = expectedHeaders[i];
+                Assert.IsNotNull(header);
+                Assert.AreEqual(expectedHeader.Key, header.Key);
+                Assert.AreEqual(GetHeaderValue(expectedHeader), GetHeaderValue(header));
+            }
+        }
+
+        [Test]
+        public void ShouldHaveHeadersDownstream()
+        {
+            StreamConfig config = new StreamConfig<StringSerDes, StringSerDes>();
+            config.ApplicationId = "test-set-headers-test";
+
+            StreamBuilder builder = new();
+
+            builder.Stream<string, string>("test")
+                .Transform(TransformerBuilder.New<string, string, string, string>()
+                    .Transformer<TestHeadersTransformer>()
+                    .Build()
+                )
+                .MapValues(value => value.ToUpper())
+                .To("test-output");
+
+            Topology t = builder.Build();
+            TopologyTestDriver driver = new(t, config);
+
+            var inputTopic = driver.CreateInputTopic<string, string>("test");
+            inputTopic.PipeInput("test-with-headers", "test-1234");
+
+            var outputTopic = driver.CreateOuputTopic<string, string>("test-output", TimeSpan.FromSeconds(10));
+
+            ConsumeResult<string, string> r = outputTopic.ReadKeyValue();
+            Assert.AreEqual("test-with-headers", r.Message.Key);
+            Assert.AreEqual("TEST-1234", r.Message.Value);
+
+            Headers rHeaders = r.Message.Headers;
+            Assert.IsNotNull(rHeaders);
+            Assert.IsTrue(rHeaders.Count > 0);
+            IHeader header = rHeaders.FirstOrDefault();
+            Assert.AreEqual("headers-test", header.Key);
+            Assert.AreEqual("headers-1234", GetHeaderValue(header));
+        }
+    }
+}


### PR DESCRIPTION
Add the ability to duplicate a record with a new set of headers. Confluent library only allows headers to be added to (not removed from, since the list is `readonly`), therefore this will allow the addition of headers between topics.