### PR TITLE
221 possibility to explicitly configure keyvalue serdes for kstreamktable join is missing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@
         - image: mcr.microsoft.com/dotnet/sdk:6.0
       steps:
         - checkout
-        - run: dotnet tool install --global dotnet-sonarscanner --version 5.5.3
+        - run: dotnet tool install --global dotnet-sonarscanner --version 5.11.0
         - run: echo 'export PATH="$PATH:/root/.dotnet/tools"' >> $BASH_ENV
         - run: echo "deb http://ftp.us.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list
         - run: apt update

--- a/core/Stream/IKStream.cs
+++ b/core/Stream/IKStream.cs
@@ -718,6 +718,12 @@ namespace Streamiz.Kafka.Net.Stream
         
         #region Join Table
 
+        IKStream<K, VR> Join<V0, VR>(IKTable<K, V0> table, Func<V, V0, VR> valueJoiner,
+            StreamTableJoinProps<K, V, V0> props, string named = null);
+
+        IKStream<K, VR> Join<V0, VR>(IKTable<K, V0> table, IValueJoiner<V, V0, VR> valueJoiner,
+            StreamTableJoinProps<K, V, V0> props, string named = null);
+
         /// <summary>
         /// Join records of this stream with <see cref="IKTable{K, V0}"/>'s records using non-windowed inner equi join with default
         /// serializers and deserializers.

--- a/core/Stream/Internal/KStream.cs
+++ b/core/Stream/Internal/KStream.cs
@@ -515,27 +515,27 @@ namespace Streamiz.Kafka.Net.Stream.Internal
         #region Join Table
 
         public IKStream<K, VR> Join<V0, VR>(IKTable<K, V0> table, Func<V, V0, VR> valueJoiner,
-            StreamTableJoinProps<K, V, V0> props, string named = null)
+            StreamTableJoinProps<K, V, V0> streamTableJoinProps, string named = null)
         {
-            KeySerdes = props.KeySerdes;
-            ValueSerdes = props.LeftValueSerdes;
+            KeySerdes = streamTableJoinProps.KeySerdes;
+            ValueSerdes = streamTableJoinProps.LeftValueSerdes;
             return Join(
                 table,
       new WrappedValueJoiner<V, V0, VR>(valueJoiner),
-                props.RightValueSerdes,
+                streamTableJoinProps.RightValueSerdes,
                 null,
                 named);
         }
 
         public IKStream<K, VR> Join<V0, VR>(IKTable<K, V0> table, IValueJoiner<V, V0, VR> valueJoiner,
-            StreamTableJoinProps<K, V, V0> props, string named = null)
+            StreamTableJoinProps<K, V, V0> streamTableJoinProps, string named = null)
         {
-            KeySerdes = props.KeySerdes;
-            ValueSerdes = props.LeftValueSerdes;
+            KeySerdes = streamTableJoinProps.KeySerdes;
+            ValueSerdes = streamTableJoinProps.LeftValueSerdes;
             return Join(
                 table,
                 valueJoiner,
-                props.RightValueSerdes,
+                streamTableJoinProps.RightValueSerdes,
                 null,
                 named);
         }
@@ -577,6 +577,32 @@ namespace Streamiz.Kafka.Net.Stream.Internal
 
         #region LeftJoin Table
 
+        public IKStream<K, VR> LeftJoin<VT, VR>(IKTable<K, VT> table, Func<V, VT, VR> valueJoiner,
+            StreamTableJoinProps<K, V, VT> streamTableJoinProps, string named = null)
+        {
+            KeySerdes = streamTableJoinProps.KeySerdes;
+            ValueSerdes = streamTableJoinProps.LeftValueSerdes;
+            return LeftJoin(
+                table,
+                new WrappedValueJoiner<V, VT, VR>(valueJoiner),
+                streamTableJoinProps.RightValueSerdes,
+                null,
+                named);
+        }
+
+        public IKStream<K, VR> LeftJoin<VT, VR>(IKTable<K, VT> table, IValueJoiner<V, VT, VR> valueJoiner,
+            StreamTableJoinProps<K, V, VT> streamTableJoinProps, string named = null)
+        {
+            KeySerdes = streamTableJoinProps.KeySerdes;
+            ValueSerdes = streamTableJoinProps.LeftValueSerdes;
+            return LeftJoin(
+                table,
+                valueJoiner,
+                streamTableJoinProps.RightValueSerdes,
+                null,
+                named);
+        }
+        
         public IKStream<K, VR> LeftJoin<VT, VR, VTS, VRS>(IKTable<K, VT> table, Func<V, VT, VR> valueJoiner, string named = null)
             where VTS : ISerDes<VT>, new()
             where VRS : ISerDes<VR>, new ()

--- a/core/Stream/Internal/KStream.cs
+++ b/core/Stream/Internal/KStream.cs
@@ -514,6 +514,32 @@ namespace Streamiz.Kafka.Net.Stream.Internal
 
         #region Join Table
 
+        public IKStream<K, VR> Join<V0, VR>(IKTable<K, V0> table, Func<V, V0, VR> valueJoiner,
+            StreamTableJoinProps<K, V, V0> props, string named = null)
+        {
+            KeySerdes = props.KeySerdes;
+            ValueSerdes = props.LeftValueSerdes;
+            return Join(
+                table,
+      new WrappedValueJoiner<V, V0, VR>(valueJoiner),
+                props.RightValueSerdes,
+                null,
+                named);
+        }
+
+        public IKStream<K, VR> Join<V0, VR>(IKTable<K, V0> table, IValueJoiner<V, V0, VR> valueJoiner,
+            StreamTableJoinProps<K, V, V0> props, string named = null)
+        {
+            KeySerdes = props.KeySerdes;
+            ValueSerdes = props.LeftValueSerdes;
+            return Join(
+                table,
+                valueJoiner,
+                props.RightValueSerdes,
+                null,
+                named);
+        }
+
         public IKStream<K, VR> Join<V0, VR, V0S, VRS>(IKTable<K, V0> table, Func<V, V0, VR> valueJoiner, string named = null)
             where V0S : ISerDes<V0>, new()
             where VRS : ISerDes<VR>, new ()

--- a/core/Stream/StreamTableJoinProps.cs
+++ b/core/Stream/StreamTableJoinProps.cs
@@ -1,0 +1,32 @@
+using Streamiz.Kafka.Net.SerDes;
+
+namespace Streamiz.Kafka.Net.Stream
+{
+    public class StreamTableJoinProps<K, V1, V2>
+    {
+        internal StreamTableJoinProps(
+            ISerDes<K> keySerdes,
+            ISerDes<V1> valueSerdes,
+            ISerDes<V2> otherValueSerdes)
+        {
+            KeySerdes = keySerdes;
+            LeftValueSerdes = valueSerdes;
+            RightValueSerdes = otherValueSerdes;
+        }
+
+        /// <summary>
+        /// Key serdes
+        /// </summary>
+        public ISerDes<K> KeySerdes { get; internal set; }
+
+        /// <summary>
+        /// Value serdes
+        /// </summary>
+        public ISerDes<V1> LeftValueSerdes { get; internal set; }
+
+        /// <summary>
+        /// Other value serdes
+        /// </summary>
+        public ISerDes<V2> RightValueSerdes { get; internal set; }
+    }
+}

--- a/test/Streamiz.Kafka.Net.Tests/FixIssue221Tests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/FixIssue221Tests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Streamiz.Kafka.Net.Mock;
+using Streamiz.Kafka.Net.SerDes;
+using Streamiz.Kafka.Net.Stream;
+using Streamiz.Kafka.Net.Table;
+
+namespace Streamiz.Kafka.Net.Tests
+{
+    public class FixIssue221Tests
+    {
+        public class Person
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+            public int LocationId { get; set; }
+            public string JobId { get; set; }
+        }
+
+        public class Location
+        {
+            public string City { get; set; }
+            public string ZipCode { get; set; }
+        }
+
+        public class PersonLocation
+        {
+            public Person Person { get; set; }
+            public Location Location { get; set; }
+        }
+
+        [Test]
+        public void FixIssue221()
+        {
+            var config = new StreamConfig<StringSerDes, StringSerDes>();
+            config.ApplicationId = "test-issue-221";
+
+            var builder = new StreamBuilder();
+
+            var stringSerdes = new StringSerDes();
+            var intSerdes = new Int32SerDes();
+            var personSerdes = new JsonSerDes<Person>();
+            var locationSerdes = new JsonSerDes<Location>();
+            
+            var personStream = builder.Stream("person", stringSerdes, personSerdes);
+            var locationTable = builder.Table("location", intSerdes, locationSerdes);
+
+            personStream
+                .Map((_, v) => KeyValuePair.Create(v.LocationId, v))
+                .Join(locationTable, 
+                    ((person, location) => new PersonLocation{Location = location, Person = person}), 
+                    new StreamTableJoinProps<int, Person, Location>(intSerdes, personSerdes, locationSerdes))
+                .To<Int32SerDes, JsonSerDes<PersonLocation>>("person-location");
+            
+            var topology = builder.Build();
+            using (var driver = new TopologyTestDriver(topology, config))
+            {
+                var personInput = driver.CreateInputTopic("person", stringSerdes, personSerdes);
+                var locationInput = driver.CreateInputTopic("location", intSerdes, locationSerdes);
+
+                var output = driver.CreateOuputTopic("person-location",
+                    TimeSpan.FromSeconds(10),
+                    intSerdes,
+                    new JsonSerDes<PersonLocation>());
+                
+                locationInput.PipeInput(1, new Location() {City = "Paris", ZipCode = "75004"});
+                personInput.PipeInput("person1", new Person(){Age = 24, Name = "Thomas", JobId = "job1", LocationId = 1});
+
+                var record = output.ReadKeyValue();
+                Assert.IsNotNull(record);
+            }
+        }
+   
+    }
+}


### PR DESCRIPTION
New methods is available at `KStream<K, V>` level. 

This methods has a new parameter `StreamTableJoinProps<K, V, V0>` to allow to set the key, left value and right value serdes  to avoid some invalid exception serdes in the downstream processors.

``` csharp
IKStream<K, VR> Join<V0, VR>(IKTable<K, V0> table, Func<V, V0, VR> valueJoiner, StreamTableJoinProps<K, V, V0> streamTableJoinProps, string named = null);

IKStream<K, VR> Join<V0, VR>(IKTable<K, V0> table, IValueJoiner<V, V0, VR> valueJoiner, StreamTableJoinProps<K, V, V0> streamTableJoinProps, string named = null);

IKStream<K, VR> LeftJoin<VT, VR>(IKTable<K, VT> table, Func<V, VT, VR> valueJoiner, StreamTableJoinProps<K, V, VT> streamTableJoinProps, string named = null);

IKStream<K, VR> LeftJoin<VT, VR>(IKTable<K, VT> table, IValueJoiner<V, VT, VR> valueJoiner, StreamTableJoinProps<K, V, VT> streamTableJoinProps, string named = null);

```