### PR TITLE
Add state stores through StreamBuilder

### DIFF
--- a/core/Stream/IKStream.cs
+++ b/core/Stream/IKStream.cs
@@ -1921,7 +1921,7 @@ namespace Streamiz.Kafka.Net.Stream
             RetryPolicy retryPolicy = null,
             RequestSerDes<K, V> requestSerDes = null,
             string named = null);
-        
+
         #endregion
 
         #region Process
@@ -1963,7 +1963,8 @@ namespace Streamiz.Kafka.Net.Stream
         /// </summary>
         /// <param name="processorSupplier">an instance of <see cref="ProcessorSupplier{K,V}"/> which contains the processor and a potential state store. Use <see cref="ProcessorBuilder"/> to build this supplier.</param>
         /// <param name="named">A <see cref="string"/> config used to name the processor in the topology. Default : null</param>
-        void Process(ProcessorSupplier<K, V> processorSupplier, string named = null);
+        /// <param name="storeNames">The names of the state stores used by the processor.</param>
+        void Process(ProcessorSupplier<K, V> processorSupplier, string named = null, params string[] storeNames);
         
         #endregion
 

--- a/core/Stream/IKStream.cs
+++ b/core/Stream/IKStream.cs
@@ -1965,7 +1965,7 @@ namespace Streamiz.Kafka.Net.Stream
         /// <param name="named">A <see cref="string"/> config used to name the processor in the topology. Default : null</param>
         /// <param name="storeNames">The names of the state stores used by the processor.</param>
         void Process(ProcessorSupplier<K, V> processorSupplier, string named = null, params string[] storeNames);
-        
+
         #endregion
 
         #region Transform
@@ -2010,11 +2010,12 @@ namespace Streamiz.Kafka.Net.Stream
         /// </summary>
         /// <param name="transformerSupplier">an instance of <see cref="TransformerSupplier{K,V,K1,V1}"/> which contains the transformer</param>
         /// <param name="named">A <see cref="string"/> config used to name the processor in the topology. Default : null</param>
+        /// <param name="storeNames">The names of the state stores used by the processor.</param>
         /// <typeparam name="K1">the key type of the new stream</typeparam>
         /// <typeparam name="V1">the value type of the new stream</typeparam>
         /// <returns>a <see cref="IKStream{K1,V1}"/> that contains more or less records with new key and value (possibly of different type)</returns>
-        IKStream<K1, V1> Transform<K1, V1>(TransformerSupplier<K, V, K1, V1> transformerSupplier, string named = null);
-        
+        IKStream<K1, V1> Transform<K1, V1>(TransformerSupplier<K, V, K1, V1> transformerSupplier, string named = null, params string[] storeNames);
+
         /// <summary>
         /// Transform each record of the input stream into zero or one record in the output stream (only value type, the original key will be through to the upstream processors ).
         /// A <see cref="Transform{K,V1}"/> (provided by the given <see cref="TransformerSupplier{K,V,K,V1}"/>) is applied to each input record and
@@ -2054,9 +2055,10 @@ namespace Streamiz.Kafka.Net.Stream
         /// </summary>
         /// <param name="transformerSupplier">an instance of <see cref="TransformerSupplier{K,V,K,V1}"/> which contains the transformer</param>
         /// <param name="named">A <see cref="string"/> config used to name the processor in the topology. Default : null</param>
+        /// <param name="storeNames">The names of the state stores used by the processor.</param>
         /// <typeparam name="V1">the value type of the new stream</typeparam>
         /// <returns>a <see cref="IKStream{K,V1}"/> that contains more or less records with new key and value (possibly of different type)</returns>
-        IKStream<K, V1> TransformValues<V1>(TransformerSupplier<K, V, K, V1> transformerSupplier, string named = null);
+        IKStream<K, V1> TransformValues<V1>(TransformerSupplier<K, V, K, V1> transformerSupplier, string named = null, params string[] storeNames);
 
         #endregion
 

--- a/core/Stream/Internal/Graph/Nodes/StateStoreNode.cs
+++ b/core/Stream/Internal/Graph/Nodes/StateStoreNode.cs
@@ -1,0 +1,20 @@
+﻿using Streamiz.Kafka.Net.Processors.Internal;
+using Streamiz.Kafka.Net.State;
+
+namespace Streamiz.Kafka.Net.Stream.Internal.Graph.Nodes
+{
+    internal class StateStoreNode : StreamGraphNode
+    {
+        private readonly IStoreBuilder storeBuilder;
+
+        public StateStoreNode(IStoreBuilder storeBuilder, string streamGraphNode) : base(streamGraphNode)
+        {
+            this.storeBuilder = storeBuilder;
+        }
+
+        public override void WriteToTopology(InternalTopologyBuilder builder)
+        {
+            builder.AddStateStore(storeBuilder);
+        }
+    }
+}

--- a/core/Stream/Internal/Graph/Nodes/StatefulProcessorNode.cs
+++ b/core/Stream/Internal/Graph/Nodes/StatefulProcessorNode.cs
@@ -1,5 +1,4 @@
-﻿using Streamiz.Kafka.Net.Processors;
-using Streamiz.Kafka.Net.Processors.Internal;
+﻿using Streamiz.Kafka.Net.Processors.Internal;
 using Streamiz.Kafka.Net.State;
 
 namespace Streamiz.Kafka.Net.Stream.Internal.Graph.Nodes
@@ -16,10 +15,12 @@ namespace Streamiz.Kafka.Net.Stream.Internal.Graph.Nodes
         /// <param name="nameNode"></param>
         /// <param name="parameters"></param>
         /// <param name="storeBuilder"></param>
-        public StatefulProcessorNode(string nameNode, ProcessorParameters<K, V> parameters, IStoreBuilder storeBuilder)
+        /// <param name="storeNames">The names of the state stores used by the processor.</param>
+
+        public StatefulProcessorNode(string nameNode, ProcessorParameters<K, V> parameters, IStoreBuilder storeBuilder, params string[] storeNames)
             : base(nameNode, parameters)
         {
-            storeNames = null;
+            this.storeNames = storeNames;
             this.storeBuilder = storeBuilder;
         }
 

--- a/core/Stream/Internal/InternalStreamBuilder.cs
+++ b/core/Stream/Internal/InternalStreamBuilder.cs
@@ -141,5 +141,15 @@ namespace Streamiz.Kafka.Net.Stream.Internal
 
 
         #endregion
+
+        #region Build Store
+        public void AddStateStore(IStoreBuilder storeBuilder)
+        {
+            var name = NewStoreName(string.Empty);
+
+            var node = new StateStoreNode(storeBuilder, name);
+            this.AddGraphNode(root, node);
+        }
+        #endregion
     }
 }

--- a/core/Stream/Internal/KStream.cs
+++ b/core/Stream/Internal/KStream.cs
@@ -118,19 +118,19 @@ namespace Streamiz.Kafka.Net.Stream.Internal
 
         #region Transform
 
-        public IKStream<K1, V1> Transform<K1, V1>(TransformerSupplier<K, V, K1, V1> transformerSupplier, string named = null)
-            => DoTransform(transformerSupplier, true, named);
+        public IKStream<K1, V1> Transform<K1, V1>(TransformerSupplier<K, V, K1, V1> transformerSupplier, string named = null, params string[] storeNames)
+            => DoTransform(transformerSupplier, true, named, storeNames);
 
-        public IKStream<K, V1> TransformValues<V1>(TransformerSupplier<K, V, K, V1> transformerSupplier, string named = null)
-            => DoTransform(transformerSupplier, false, named);
+        public IKStream<K, V1> TransformValues<V1>(TransformerSupplier<K, V, K, V1> transformerSupplier, string named = null, params string[] storeNames)
+            => DoTransform(transformerSupplier, false, named, storeNames);
         
         private IKStream<K1, V1> DoTransform<K1, V1>(TransformerSupplier<K, V, K1, V1> transformerSupplier, bool changeKey, string named =
-            null)
+            null, params string[] storeNames)
         {
             string name = new Named(named).OrElseGenerateWithPrefix(builder, changeKey ? KStream.TRANSFORM_NAME : KStream.TRANSFORMVALUES_NAME );
             ProcessorParameters<K, V> processorParameters = new ProcessorParameters<K, V>(
                 new KStreamTransformerSupplier<K, V, K1, V1>(transformerSupplier, changeKey), name);
-            StatefulProcessorNode<K, V> processorNode = new StatefulProcessorNode<K, V>(name, processorParameters, transformerSupplier.StoreBuilder);
+            StatefulProcessorNode<K, V> processorNode = new StatefulProcessorNode<K, V>(name, processorParameters, transformerSupplier.StoreBuilder, storeNames);
 
             builder.AddGraphNode(Node, processorNode);
             

--- a/core/Stream/Internal/KStream.cs
+++ b/core/Stream/Internal/KStream.cs
@@ -104,12 +104,12 @@ namespace Streamiz.Kafka.Net.Stream.Internal
         
         #region Process
 
-        public void Process(ProcessorSupplier<K, V> processorSupplier, string named = null)
+        public void Process(ProcessorSupplier<K, V> processorSupplier, string named = null, params string[] storeNames)
         {
             string name = new Named(named).OrElseGenerateWithPrefix(builder, KStream.PROCESSOR_NAME);
             ProcessorParameters<K, V> processorParameters = new ProcessorParameters<K, V>(
                 new KStreamProcessorSupplier<K, V>(processorSupplier), name);
-            StatefulProcessorNode<K, V> processorNode = new StatefulProcessorNode<K, V>(name, processorParameters, processorSupplier.StoreBuilder);
+            StatefulProcessorNode<K, V> processorNode = new StatefulProcessorNode<K, V>(name, processorParameters, processorSupplier.StoreBuilder, storeNames);
 
             builder.AddGraphNode(Node, processorNode);
         }

--- a/core/StreamBuilder.cs
+++ b/core/StreamBuilder.cs
@@ -737,6 +737,22 @@ namespace Streamiz.Kafka.Net
 
         #endregion
 
+        #region State Store
+
+        /// <summary>
+        /// Adds a state store to the underlying <see cref="Topology"/>. 
+        /// It is required to connect state stores to <see cref="Streamiz.Kafka.Net.Processors.Public.IProcessor{K, V}"/> 
+        /// or <see cref="Streamiz.Kafka.Net.Processors.Public.ITransformer{K, V, K1, V1}"/>
+        /// before they can be used.
+        /// </summary>
+        /// <param name="storeBuilder">The builder used to obtain the <see cref="IStateStore"/> instance.</param>
+        public void AddStateStore(IStoreBuilder storeBuilder)
+        {
+            internalStreamBuilder.AddStateStore(storeBuilder);
+        }
+
+        #endregion
+
         /// <summary>
         /// Returns the <see cref="Topology"/> that represents the specified processing logic.
         /// Note that using this method means no optimizations are performed.


### PR DESCRIPTION
### Changes:
- [X] state stores can be added to topology though `StreamBuilder.AddStateStore`

> NOTE: It's required to connect state stores to `IProcessor<K, V>` or `ITransformer<K, V, K1, V1>` before use it.

### Example:
1. Add a state store
```
        var builder = new StreamBuilder();
        var storeBuilder = Stores.KeyValueStoreBuilder<K, V>(
            Stores.InMemoryKeyValueStore("output-store"),
            new JsonSerDes<K>(),
            new JsonSerDes<V>());

        builder.AddStateStore(storeBuilder);
```

2. Connect the state store with the transformer or processor by passing the store name to storeNames parameter of `Process`, `Transform` or `TransformValues` method:
```
     builder.Stream<K, V>("topic-name")
            .Transform(
                TransformerBuilder.New<K, V, K1, V1>().Transformer<TTransformer>().Build(), 
                storeNames: "output-store")
```
3. The state store now can be retrieved in `TTransformer.Init` and can be used later when `TTransformer.Process` is called
```
        public void Init(ProcessorContext<K, V> context)
        { 
            stateStore = (IKeyValueStore<K, V>)context.GetStateStore("output-store");
        }
```