### PR TITLE
SSL Key and Cert disclosed in logs #277

### DIFF
--- a/core/StreamConfig.cs
+++ b/core/StreamConfig.cs
@@ -3039,7 +3039,9 @@ namespace Streamiz.Kafka.Net
             List<string> keysToNotDisplay = new List<string> {
                 "sasl.password",
                 "ssl.key.password",
-                "ssl.keystore.password"
+                "ssl.keystore.password",
+                "ssl.key.pem",
+                "ssl.certificate.pem"
             };
 
             List<string> keysAlreadyPrint = new List<string>();


### PR DESCRIPTION
Add `ssl.key.pem` and `ssl.certificate.pem`  to the skipped list in the `StreamConfig.ToString()`