### PR TITLE
updates kafka dependency to 2.3 and fixes breaking changes

### DIFF
--- a/core/Streamiz.Kafka.Net.csproj
+++ b/core/Streamiz.Kafka.Net.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RocksDB" Version="7.7.3.33461" />
-    <PackageReference Include="Confluent.Kafka" Version="2.2.0" />
+    <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro.csproj
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Avro.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.2.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.2.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.3.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Json/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Json.csproj
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Json/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Json.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.2.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.2.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.3.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Protobuf/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Protobuf.csproj
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Protobuf/Streamiz.Kafka.Net.SchemaRegistry.SerDes.Protobuf.csproj
@@ -31,8 +31,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.2.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.2.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.3.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes/MockSchemaRegistryClient.cs
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes/MockSchemaRegistryClient.cs
@@ -349,9 +349,34 @@ namespace Streamiz.Kafka.Net.SchemaRegistry.SerDes.Mock
         /// <returns>A unique id identifying the schema.</returns>
         public Task<int> RegisterSchemaAsync(string subject, Schema schema)
             => RegisterSchemaAsync(subject, schema.SchemaString);
+        
+        /// <summary>
+        ///     If the subject is specified returns compatibility type for the specified subject.
+        ///     Otherwise returns global compatibility type.
+        /// </summary>
+        /// <param name="subject">
+        ///     The subject to get the compatibility for.
+        /// </param>
+        /// <returns>Compatibility type.</returns>
+        public Task<Compatibility> GetCompatibilityAsync(string subject = null)
+        {
+            return Task.FromResult(Compatibility.None);
+        }
+        
+        /// <summary>
+        ///     If the subject is specified sets compatibility type for the specified subject.
+        ///     Otherwise sets global compatibility type.
+        /// </summary>
+        /// <param name="subject">
+        ///      The subject to set the compatibility for.
+        /// </param>
+        /// <param name="compatibility">Compatibility type.</param>
+        /// <returns>New compatibility type.</returns>
+        public Task<Compatibility> UpdateCompatibilityAsync(Compatibility compatibility, string subject = null)
+        {
+            return Task.FromResult(compatibility);
+        }
 
         #endregion ISchemaRegistryClient Impl
-        
-        
     }
 }

--- a/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.csproj
+++ b/serdes/Streamiz.Kafka.Net.SchemaRegistry.SerDes/Streamiz.Kafka.Net.SchemaRegistry.SerDes.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.2.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Consumer/Consumer.csproj
+++ b/test/Consumer/Consumer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.2.0" />
+    <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Producer-Avro/Producer-Avro.csproj
+++ b/test/Producer-Avro/Producer-Avro.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.2.0" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.2.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.2.0" />
+    <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.3.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.3.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Producer/Producer.csproj
+++ b/test/Producer/Producer.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.2.0" />
+    <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
"Confluent.SchemaRegistry" Version 2.3 introduced unnamed breaking changes, as there were additional methods introduced in the "ISchemaRegistryClient" interface. This leads to assembly incompatibility between "Confluent.SchemaRegistry" V2.3 and "Streamiz.Kafka.Net.SchemaRegistry.SerDes" V1.5.1 for every project that uses tests that require the SchemaRegistry Mock, as the MockSchemaRegistryClient implements the breaking interface.

This PR updates the Kafka dependencies to Version 2.3 and fixes the breaking changes.

It would be nice to release this soon as the current state does not allow to update to Kafka Client Version 2.3