### PR TITLE
Topic record timestamp extractor

### DIFF
--- a/core/Processors/IRecordTimestampExtractor.cs
+++ b/core/Processors/IRecordTimestampExtractor.cs
@@ -1,0 +1,20 @@
+﻿namespace Streamiz.Kafka.Net.Processors
+{
+    /// <summary>
+    /// An interface that allows to dynamically determine the timestamp of the record stored in the Kafka topic.
+    /// </summary>
+    /// <typeparam name="K">Key type</typeparam>
+    /// <typeparam name="V">Value type</typeparam>
+    public interface IRecordTimestampExtractor<K,V>
+    {
+        /// <summary>
+        /// Extracts the timestamp of the record stored in the Kafka topic.
+        /// </summary>
+        /// <param name="key">the record key</param>
+        /// <param name="value">the record value</param>
+        /// <param name="recordContext">current context metadata of the record</param>
+        /// <returns>the timestamp of the record</returns>
+        long Extract(K key, V value, IRecordContext recordContext);
+
+    }
+}

--- a/core/Processors/Internal/DefaultRecordTimestampExtractor.cs
+++ b/core/Processors/Internal/DefaultRecordTimestampExtractor.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Streamiz.Kafka.Net.Processors.Internal
+{
+    internal class DefaultRecordTimestampExtractor<K, V> : IRecordTimestampExtractor<K, V>
+    {
+        private readonly Func<K, V, IRecordContext, long> timestampExtractor;
+
+        public DefaultRecordTimestampExtractor()
+        {
+            this.timestampExtractor = (k, v, ctx) => ctx.Timestamp;
+        }
+
+        public long Extract(K key, V value, IRecordContext recordContext) => timestampExtractor(key, value, recordContext);
+    }
+}

--- a/core/Processors/Internal/InternalTopologyBuilder.cs
+++ b/core/Processors/Internal/InternalTopologyBuilder.cs
@@ -153,7 +153,7 @@ namespace Streamiz.Kafka.Net.Processors.Internal
             nodeGroups = null;
         }
 
-        internal void AddSinkOperator<K, V>(ITopicNameExtractor<K, V> topicNameExtractor, string nameNode, Produced<K, V> produced, params string[] previousProcessorNames)
+        internal void AddSinkOperator<K, V>(ITopicNameExtractor<K, V> topicNameExtractor, IRecordTimestampExtractor<K, V> timestampExtractor, string nameNode, Produced<K, V> produced, params string[] previousProcessorNames)
         {
             if (nodeFactories.ContainsKey(nameNode))
             {
@@ -161,7 +161,7 @@ namespace Streamiz.Kafka.Net.Processors.Internal
             }
 
             nodeFactories.Add(nameNode,
-                new SinkNodeFactory<K, V>(nameNode, previousProcessorNames, topicNameExtractor, produced.KeySerdes, produced.ValueSerdes, produced.Partitioner));
+                new SinkNodeFactory<K, V>(nameNode, previousProcessorNames, topicNameExtractor, timestampExtractor, produced.KeySerdes, produced.ValueSerdes, produced.Partitioner));
             nodeGrouper.Add(nameNode);
             nodeGrouper.Unite(nameNode, previousProcessorNames);
             nodeGroups = null;

--- a/core/Processors/Internal/WrapperRecordTimestampExtractor.cs
+++ b/core/Processors/Internal/WrapperRecordTimestampExtractor.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Streamiz.Kafka.Net.Processors.Internal
+{
+    internal class WrapperRecordTimestampExtractor<K, V> : IRecordTimestampExtractor<K, V>
+    {
+        private readonly Func<K, V, IRecordContext, long> timestampExtractor;
+
+        public WrapperRecordTimestampExtractor(Func<K,V,IRecordContext,long> timestampExtractor)
+        {
+            this.timestampExtractor = timestampExtractor;
+        }
+
+        public long Extract(K key, V value, IRecordContext recordContext) => timestampExtractor(key, value ,recordContext);
+    }
+}

--- a/core/Stream/IKStream.cs
+++ b/core/Stream/IKStream.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Streamiz.Kafka.Net.Processors.Public;
+using Streamiz.Kafka.Net.Processors.Internal;
 
 namespace Streamiz.Kafka.Net.Stream
 {
@@ -162,6 +163,45 @@ namespace Streamiz.Kafka.Net.Stream
         /// <param name="named">A <see cref="string"/> config used to name the processor in the topology. Default : null</param>
         void To(ITopicNameExtractor<K, V> topicExtractor, ISerDes<K> keySerdes, ISerDes<V> valueSerdes, string named = null);
 
+        /// <summary>
+        /// Dynamically materialize this stream to topics using default serializers specified in the config and producer's.
+        /// The topic names for each record to send to is dynamically determined based on the <code>Func&lt;K, V, IRecordContext, string&gt;</code>.
+        /// </summary>
+        /// <param name="topicExtractor">Extractor function to determine the name of the Kafka topic to write to for each record</param>
+        /// <param name="recordTimestampExtractor">Extractor function to determine the timestamp of the record stored in the Kafka topic</param>
+        /// <param name="named">A <see cref="string"/> config used to name the processor in the topology. Default : null</param>
+        void To(Func<K, V, IRecordContext, string> topicExtractor, Func<K, V, IRecordContext, long> recordTimestampExtractor, string named = null);
+
+        /// <summary>
+        /// Dynamically materialize this stream to topics using default serializers specified in the config and producer's.
+        /// The topic names for each record to send to is dynamically determined based on the <code>Func&lt;K, V, IRecordContext, string&gt;</code>.
+        /// </summary>
+        /// <param name="topicExtractor">Extractor function to determine the name of the Kafka topic to write to for each record</param>
+        /// <param name="keySerdes">Key serializer</param>
+        /// <param name="valueSerdes">Value serializer</param>
+        /// <param name="recordTimestampExtractor">Extractor function to determine the timestamp of the record stored in the Kafka topic</param>
+        /// <param name="named">A <see cref="string"/> config used to name the processor in the topology. Default : null</param>
+        void To(Func<K, V, IRecordContext, string> topicExtractor, ISerDes<K> keySerdes, ISerDes<V> valueSerdes, Func<K, V, IRecordContext, long> recordTimestampExtractor, string named = null);
+
+        /// <summary>
+        /// Dynamically materialize this stream to topics using default serializers specified in the config and producer's.
+        /// The topic names for each record to send to is dynamically determined based on the <see cref="ITopicNameExtractor&lt;K, V&gt;"/>}.
+        /// </summary>
+        /// <param name="topicExtractor">The extractor to determine the name of the Kafka topic to write to for each record</param>
+        /// <param name="recordTimestampExtractor">Extractor function to determine the timestamp of the record stored in the Kafka topic</param>
+        /// <param name="named">A <see cref="string"/> config used to name the processor in the topology. Default : null</param>
+        void To(ITopicNameExtractor<K, V> topicExtractor, IRecordTimestampExtractor<K, V> recordTimestampExtractor, string named = null);
+
+        /// <summary>
+        /// Dynamically materialize this stream to a topic using serializers specified in the method parameters.
+        /// The topic names for each record to send to is dynamically determined based on the <see cref="ITopicNameExtractor&lt;K, V&gt;"/>}.
+        /// </summary>
+        /// <param name="topicExtractor">The extractor to determine the name of the Kafka topic to write to for each record</param>4
+        /// <param name="keySerdes">Key serializer</param>
+        /// <param name="valueSerdes">Value serializer</param>
+        /// <param name="recordTimestampExtractor">Extractor function to determine the timestamp of the record stored in the Kafka topic</param>
+        /// <param name="named">A <see cref="string"/> config used to name the processor in the topology. Default : null</param>
+        void To(ITopicNameExtractor<K, V> topicExtractor, ISerDes<K> keySerdes, ISerDes<V> valueSerdes, IRecordTimestampExtractor<K, V> recordTimestampExtractor, string named = null);
 
         /// <summary>
         /// Materialize this stream to a topic using <typeparamref name="KS"/> and <typeparamref name="VS"/> serializers specified in the method parameters.
@@ -194,8 +234,30 @@ namespace Streamiz.Kafka.Net.Stream
         /// <param name="named">A <see cref="string"/> config used to name the processor in the topology. Default : null</param>
         void To<KS, VS>(ITopicNameExtractor<K, V> topicExtractor, string named = null) where KS : ISerDes<K>, new() where VS : ISerDes<V>, new();
 
-        #endregion
+        /// <summary>
+        /// Dynamically materialize this stream to a topic using <typeparamref name="KS"/> and <typeparamref name="VS"/> serializers specified in the method parameters.
+        /// The topic names for each record to send to is dynamically determined based on the <code>Func&lt;K, V, IRecordContext, string&gt;</code>.
+        /// </summary>
+        /// <typeparam name="KS">New type key serializer</typeparam>
+        /// <typeparam name="VS">New type value serializer</typeparam>
+        /// <param name="topicExtractor">Extractor function to determine the name of the Kafka topic to write to for each record</param>
+        /// <param name="recordTimestampExtractor">Extractor function to determine the timestamp of the record stored in the Kafka topic</param>
+        /// <param name="named">A <see cref="string"/> config used to name the processor in the topology. Default : null</param>
+        void To<KS, VS>(Func<K, V, IRecordContext, string> topicExtractor, Func<K, V, IRecordContext, long> recordTimestampExtractor, string named = null) where KS : ISerDes<K>, new() where VS : ISerDes<V>, new();
+
+        /// <summary>
+        /// Dynamically materialize this stream to a topic using <typeparamref name="KS"/> and <typeparamref name="VS"/> serializers specified in the method parameters.
+        /// The topic names for each record to send to is dynamically determined based on the <see cref="ITopicNameExtractor&lt;K, V&gt;"/>}.
+        /// </summary>
+        /// <typeparam name="KS">New type key serializer</typeparam>
+        /// <typeparam name="VS">New type value serializer</typeparam>
+        /// <param name="topicExtractor">The extractor to determine the name of the Kafka topic to write to for each record</param>
+        /// <param name="recordTimestampExtractor">Extractor function to determine the timestamp of the record stored in the Kafka topic</param>
+        /// <param name="named">A <see cref="string"/> config used to name the processor in the topology. Default : null</param>
+        void To<KS, VS>(ITopicNameExtractor<K, V> topicExtractor, IRecordTimestampExtractor<K, V> recordTimestampExtractor, string named = null) where KS : ISerDes<K>, new() where VS : ISerDes<V>, new();
         
+        #endregion
+
         #region FlatMap
 
         /// <summary>

--- a/core/Stream/Internal/Graph/Nodes/AsyncNode.cs
+++ b/core/Stream/Internal/Graph/Nodes/AsyncNode.cs
@@ -34,6 +34,7 @@ namespace Streamiz.Kafka.Net.Stream.Internal.Graph.Nodes
                 builder.AddInternalTopic(RepartitionTopic, null);
                 builder.AddSinkOperator(
                     new StaticTopicNameExtractor<TK, TV>(RepartitionTopic),
+                    new DefaultRecordTimestampExtractor<TK, TV>(),
                     SinkName,
                     Produced<TK, TV>.Create(KeySerdes, ValueSerdes),
                     ParentNodeNames());
@@ -70,6 +71,7 @@ namespace Streamiz.Kafka.Net.Stream.Internal.Graph.Nodes
                 builder.AddInternalTopic(RepartitionTopic, null);
                 builder.AddProcessor(ProcessorParameters.ProcessorName, ProcessorParameters.Processor, ParentNodeNames());
                 builder.AddSinkOperator(new StaticTopicNameExtractor<TK1, TV1>(RepartitionTopic),
+                    new DefaultRecordTimestampExtractor<TK1, TV1>(),
                         SinkName,
                         Produced<TK1, TV1>.Create(KeySerdes, ValueSerdes),
                         ProcessorParameters.ProcessorName);
@@ -112,6 +114,7 @@ namespace Streamiz.Kafka.Net.Stream.Internal.Graph.Nodes
             {
                 builder.AddInternalTopic(RequestTopic, null);
                 builder.AddSinkOperator(new StaticTopicNameExtractor<TK, TV>(RequestTopic),
+                    new DefaultRecordTimestampExtractor<TK, TV>(),
                     SinkName,
                     Produced<TK, TV>.Create(KeySerdes, ValueSerdes),
                     ParentNodeNames());

--- a/core/Stream/Internal/Graph/Nodes/RepartitionNode.cs
+++ b/core/Stream/Internal/Graph/Nodes/RepartitionNode.cs
@@ -23,6 +23,7 @@ namespace Streamiz.Kafka.Net.Stream.Internal.Graph.Nodes
                     ParentNodeNames());
                 builder.AddSinkOperator(
                     new StaticTopicNameExtractor<K, V>(RepartitionTopic),
+                    new DefaultRecordTimestampExtractor<K, V>(),
                     SinkName,
                     Produced<K, V>.Create(KeySerdes, ValueSerdes).WithPartitioner(StreamPartitioner),
                     ProcessorParameters.ProcessorName);
@@ -36,6 +37,7 @@ namespace Streamiz.Kafka.Net.Stream.Internal.Graph.Nodes
                 builder.AddInternalTopic(RepartitionTopic, NumberOfPartition);
                 builder.AddSinkOperator(
                     new StaticTopicNameExtractor<K, V>(RepartitionTopic),
+                    new DefaultRecordTimestampExtractor<K, V>(),
                     SinkName,
                     Produced<K, V>.Create(KeySerdes, ValueSerdes).WithPartitioner(StreamPartitioner),
                     ParentNodeNames());

--- a/core/Stream/Internal/Graph/Nodes/StreamSinkNode.cs
+++ b/core/Stream/Internal/Graph/Nodes/StreamSinkNode.cs
@@ -15,17 +15,19 @@ namespace Streamiz.Kafka.Net.Stream.Internal.Graph.Nodes
     {
         private readonly ITopicNameExtractor<K, V> topicNameExtractor;
         private readonly Produced<K, V> produced;
+        private readonly IRecordTimestampExtractor<K, V> timestampExtractor;
 
-        public StreamSinkNode(ITopicNameExtractor<K, V> topicNameExtractor, string streamGraphNode, Produced<K, V> produced)
+        public StreamSinkNode(ITopicNameExtractor<K, V> topicNameExtractor, IRecordTimestampExtractor<K, V> timestampExtractor, string streamGraphNode, Produced<K, V> produced)
             : base(streamGraphNode)
         {
             this.topicNameExtractor = topicNameExtractor;
+            this.timestampExtractor = timestampExtractor;
             this.produced = produced;
         }
 
         public override void WriteToTopology(InternalTopologyBuilder builder)
         {
-            builder.AddSinkOperator(topicNameExtractor, this.streamGraphNode, produced, ParentNodeNames());
+            builder.AddSinkOperator(topicNameExtractor, timestampExtractor, this.streamGraphNode, produced, ParentNodeNames());
         }
     }
 }

--- a/test/Streamiz.Kafka.Net.Tests/Private/StreamGraphNodeTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Private/StreamGraphNodeTests.cs
@@ -77,7 +77,9 @@ namespace Streamiz.Kafka.Net.Tests.Private
             nodes.Add(filter);
 
             var to = new StreamSinkNode<string, string>(
-                new StaticTopicNameExtractor<string, string>("topic2"), "to-03",
+                new StaticTopicNameExtractor<string, string>("topic2"),
+                new DefaultRecordTimestampExtractor<string, string>(),
+                "to-03",
                 new Stream.Internal.Produced<string, string>(
                     new StringSerDes(),
                     new StringSerDes())

--- a/test/Streamiz.Kafka.Net.Tests/Processors/KStreamRecordTimestampExtractorTests.cs
+++ b/test/Streamiz.Kafka.Net.Tests/Processors/KStreamRecordTimestampExtractorTests.cs
@@ -1,0 +1,120 @@
+﻿using Confluent.Kafka;
+using NUnit.Framework;
+using Streamiz.Kafka.Net.Mock;
+using Streamiz.Kafka.Net.Processors;
+using Streamiz.Kafka.Net.SerDes;
+using Streamiz.Kafka.Net.Stream;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Streamiz.Kafka.Net.Tests.Processors
+{
+    public class KStreamRecordTimestampExtractorTests
+    {
+        private class MyTimestampExtractor : ITimestampExtractor
+        {
+            public long Extract(ConsumeResult<object, object> record, long partitionTime)
+            {
+                return Timestamp.DateTimeToUnixTimestampMs(DateTime.UtcNow);
+            }
+        }
+
+        [TestCase(0)]
+        [TestCase(12345)]
+        [TestCase(int.MaxValue)]
+        public void StreamWithIngestionTimeTest(long customTimestamp)
+        {
+            var builder = new StreamBuilder();
+            var data = new List<KeyValuePair<string, string>>() { KeyValuePair.Create("key1", "123456") };
+
+            builder.Stream<string, string>("topic")
+                .To((k,v,ctx) => "output-topic", (k,v,ctx) => customTimestamp);
+
+            var config = new StreamConfig<StringSerDes, StringSerDes>();
+            config.ApplicationId = "test-flatmap";
+
+            Topology t = builder.Build();
+
+            using (var driver = new TopologyTestDriver(t, config))
+            {
+                var inputTopic = driver.CreateInputTopic<string, string>("topic");
+                var outputTopic = driver.CreateOuputTopic<string, string, StringSerDes, StringSerDes>("output-topic");
+
+                inputTopic.PipeInputs(data);
+                var result = outputTopic.ReadKeyValueList().ToList();
+
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Count == 1);
+                var record = result[0];
+                Assert.AreEqual(customTimestamp, record.Message.Timestamp.UnixTimestampMs);
+            }
+        }
+
+        [TestCase(0)]
+        [TestCase(12345)]
+        [TestCase(int.MaxValue)]
+        public void StreamWithStreamTimestampExtractorTest(long customTimestamp)
+        {
+            var builder = new StreamBuilder();
+            var data = new List<KeyValuePair<string, string>>() { KeyValuePair.Create("key1", "123456") };
+
+            builder.Stream<string, string>("topic",
+                new StringSerDes(),
+                new StringSerDes(),
+                new MyTimestampExtractor())
+                .To((k, v, ctx) => "output-topic", (k, v, ctx) => customTimestamp);
+
+            var config = new StreamConfig<StringSerDes, StringSerDes>();
+            config.ApplicationId = "test-flatmap";
+
+            Topology t = builder.Build();
+
+            using (var driver = new TopologyTestDriver(t, config))
+            {
+                var inputTopic = driver.CreateInputTopic<string, string>("topic");
+                var outputTopic = driver.CreateOuputTopic<string, string, StringSerDes, StringSerDes>("output-topic");
+
+                inputTopic.PipeInputs(data);
+                var result = outputTopic.ReadKeyValueList().ToList();
+
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Count == 1);
+                var record = result[0];
+                Assert.AreEqual(customTimestamp, record.Message.Timestamp.UnixTimestampMs);
+            }
+        }
+
+        [TestCase(0)]
+        [TestCase(12345)]
+        [TestCase(int.MaxValue)]
+        public void WhenStreamWithOverriddenTimestamp(long customTimestamp)
+        {
+            var builder = new StreamBuilder();
+            var data = new List<KeyValuePair<string, string>>() { KeyValuePair.Create("key1", "123456") };
+
+            builder.Stream<string, string>("topic")
+                .WithRecordTimestamp((k, v) => customTimestamp + 3600)
+                .To((k, v, ctx) => "output-topic", (k, v, ctx) => customTimestamp);
+
+            var config = new StreamConfig<StringSerDes, StringSerDes>();
+            config.ApplicationId = "test-flatmap";
+
+            Topology t = builder.Build();
+
+            using (var driver = new TopologyTestDriver(t, config))
+            {
+                var inputTopic = driver.CreateInputTopic<string, string>("topic");
+                var outputTopic = driver.CreateOuputTopic<string, string, StringSerDes, StringSerDes>("output-topic");
+
+                inputTopic.PipeInputs(data);
+                var result = outputTopic.ReadKeyValueList().ToList();
+
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Count == 1);
+                var record = result[0];
+                Assert.AreEqual(customTimestamp, record.Message.Timestamp.UnixTimestampMs);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Provides control over timestamp value of records published to Kafka output topic.

Some context below:
Q: How this functionality is different than `ITimestampExtractor` applied to a source stream or `IKStream<K, V>.WithRecordTimestamp` applied to some existing stream?

A: In simple scenarios either method can be used to provide timestamps for the records sent to the output topic.
For example `ITimestampExtractor` provides the initial value for `RecordContext.Timestamp`, whereas `IKStream<K, V>.WithRecordTimestamp` can override that value later. 
However in some scenarios you might need more grained control over what timestamp is applied to the output topic records and change that timestamp without affecting the `RecordContext.Timestamp` of underlying stream.

Example with pseudo code which WON'T WORK:
```
var joinedStream = stream1.WithRecordTimestamp(m1 => m1.Timestamp) LEFT JOIN stream2.WithRecordTimestamp(m2 => m2.Timestamp);
joinedStream.WithRecordTimestamp(utcNow).To("output-topic")
```
This basically will break your join because applying `joinedStream.WithRecordTimestamp(utcNow)` will override the timestamp in `RecordContext.Timestamp` and value stored by `KStreamJoinWindowProcessor`  into the `window` store will be utcNow as all topology processors are executed first:
```
        public override void Process(K key, V value)
        {
            if(key != null)
            {
                Forward(key, value);
                window.Put(key, value, Context.Timestamp);
            }
        }
```

The solution I came up with is to bring the desired `timestamp` value directly to `SinkProcessor` without touching the value in  `RecordContext.Timestamp` at all.

Example with pseudo code which WORKS with changes proposed by this PR:
```
var joinedStream = stream1.WithRecordTimestamp(m1 => m1.Timestamp) LEFT JOIN stream2.WithRecordTimestamp(m2 => m2.Timestamp);
joinedStream.To("output-topic", extractor => utcNow)
```




