### PR TITLE
Fix HasRestoredToEnd() stuck when beginOffset == endOffset (#463)

### DIFF
--- a/core/Processors/Internal/StoreChangelogReader.cs
+++ b/core/Processors/Internal/StoreChangelogReader.cs
@@ -266,7 +266,7 @@ namespace Streamiz.Kafka.Net.Processors.Internal
            
             if(changelogMetadata.CurrentOffset >= endOffset 
                // changelog topic has a delete policy, begin offset > end offset because the topic is empty #195
-               || changelogMetadata.BeginOffset > changelogMetadata.RestoreEndOffset)
+               || changelogMetadata.BeginOffset >= changelogMetadata.RestoreEndOffset)
                 return true;
             
             if (!changelogMetadata.BufferedRecords.Any())


### PR DESCRIPTION
When a changelog topic is empty after segment deletion (beginOffset == endOffset) and no checkpoint exists, the restore consumer has nothing to consume but HasRestoredToEnd() returns false forever because the strict > comparison misses the == case.

Change > to >= to correctly detect empty topics.